### PR TITLE
Don't import sdk_version_hash into root of package

### DIFF
--- a/examples_utils/__init__.py
+++ b/examples_utils/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 
-from .sdk_version_hash import *
+# Don't import sdk_version_hash here
 from .parsing import *
 from .load_lib import *

--- a/examples_utils/load_lib/load_lib.py
+++ b/examples_utils/load_lib/load_lib.py
@@ -9,7 +9,7 @@ from cppimport.checksum import is_checksum_valid
 from cppimport.importer import get_module_name, get_extension_suffix, setup_module_data, template_and_build
 from filelock import FileLock, Timeout
 
-from examples_utils import sdk_version_hash
+from examples_utils.sdk_version_hash import sdk_version_hash
 import os
 import logging
 

--- a/tests/test_custom_ops.py
+++ b/tests/test_custom_ops.py
@@ -93,7 +93,7 @@ def test_custom_ops_sdk_change():
     binary_hash = md5_file_hash(binary_path)
 
     # Test loading again when sdk has changed (monkey patch `sdk_version_hash` function)
-    with patch('examples_utils.load_lib.custom_ops_utils.sdk_version_hash', new=lambda: 'patch-version'):
+    with patch('examples_utils.load_lib.load_lib.sdk_version_hash', new=lambda: 'patch-version'):
         load_lib(cpp_file.name)
         binary_path_new = get_binary_path(cpp_file.name)
         assert 'patch-version' in binary_path_new, 'Monkey patch has not worked. Is the path correct?'

--- a/tests/test_sdk_version_hash.py
+++ b/tests/test_sdk_version_hash.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 
-from examples_utils import sdk_version_hash
+from examples_utils.sdk_version_hash import sdk_version_hash
 
 
 def test_sdk_version():


### PR DESCRIPTION
Don't import sdk_version_hash into root of package to prevent an automatic compilation on package import