### PR TITLE
Removing reptil and all associated imports/functions

### DIFF
--- a/examples_utils/benchmarks/profiling_utils.py
+++ b/examples_utils/benchmarks/profiling_utils.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import numpy as np
 import json
-import reptil
+#import reptil
 import logging
 from pathlib import Path
 
@@ -37,99 +37,97 @@ def add_profiling_vars(current_env: dict, benchmark_name: str, app_dir: str) -> 
     return current_env
 
 
-def log_profile_summary(report: reptil.Reptil) -> str:
-    """
-    Analyse and extract information from a popvision profile report.
+# def log_profile_summary(report: reptil.Reptil) -> str:
+#     """
+#     Analyse and extract information from a popvision profile report.
 
-    Args:
-        report (reptil.Reptil): Reptil profile report object
+#     Args:
+#         report (reptil.Reptil): Reptil profile report object
 
-    Returns:
-        mem_writeout (str): A single string writeout of all useful memory
-            information from this report
+#     Returns:
+#         mem_writeout (str): A single string writeout of all useful memory
+#             information from this report
 
-    """
+#     """
 
-    # Get summary statistics from report
-    summary = report.memory.summary()
-    mem_writeout = ("Memory usage summary statistics:\n" +
-                    "Peak liveness: {}\n".format(summary["Peak liveness"]["total"]) +
-                    "\tAs a proportion: {},\n".format(summary["Peak liveness"]["proportion"]))
+#     # Get summary statistics from report
+#     summary = report.memory.summary()
+#     mem_writeout = ("Memory usage summary statistics:\n" +
+#                     "Peak liveness: {}\n".format(summary["Peak liveness"]["total"]) +
+#                     "\tAs a proportion: {},\n".format(summary["Peak liveness"]["proportion"]))
 
-    mem_writeout += "Split by categories (megabytes): \n"
-    for k, v in summary["Memory categories"].items():
-        mem_writeout += f"\t{k}: {v*(1024**-2)}\n"
+#     mem_writeout += "Split by categories (megabytes): \n"
+#     for k, v in summary["Memory categories"].items():
+#         mem_writeout += f"\t{k}: {v*(1024**-2)}\n"
 
-    mem_writeout += "Overall memory usage (per IPU, megabytes):\n"
-    for k, v in summary["IPU level"].items():
-        mem_writeout += f"\t{k}: {v*(1024**-2)}\n"
+#     mem_writeout += "Overall memory usage (per IPU, megabytes):\n"
+#     for k, v in summary["IPU level"].items():
+#         mem_writeout += f"\t{k}: {v*(1024**-2)}\n"
 
-    mem_writeout += "Detailed breakdown (per Tile, bytes):\n"
-    for ipu_id, tile_summary in summary["Tile level"].items():
-        mem_writeout += f"\t{ipu_id}:\n"
-        for k, v in tile_summary.items():
-            mem_writeout += f"\t\t{k}: {v}\n"
+#     mem_writeout += "Detailed breakdown (per Tile, bytes):\n"
+#     for ipu_id, tile_summary in summary["Tile level"].items():
+#         mem_writeout += f"\t{ipu_id}:\n"
+#         for k, v in tile_summary.items():
+#             mem_writeout += f"\t\t{k}: {v}\n"
 
-    # Output to logs too
-    logger.info(mem_writeout)
+#     # Output to logs too
+#     logger.info(mem_writeout)
 
-    return mem_writeout
+#     return mem_writeout
 
+# def save_profile_breakdowns(report: reptil.Reptil, dir: Path):
+#     """Save detailed memory usage breakdowns locally to csv.
 
-def save_profile_breakdowns(report: reptil.Reptil, dir: Path):
-    """Save detailed memory usage breakdowns locally to csv.
+#     Args:
+#         report (reptil.Reptil): Reptil profile report object
+#         dir (pathlib.Path): Dir path to save files to
 
-    Args:
-        report (reptil.Reptil): Reptil profile report object
-        dir (pathlib.Path): Dir path to save files to
+#     """
 
-    """
+#     # All the memory categories of interest
+#     memory_categories = [
+#         "vertex",
+#         "control",
+#         "exchange",
+#         "constants",
+#         "always_live",
+#         "including_gaps",
+#         "excluding_gaps",
+#         "not_always_live",
+#     ]
 
-    # All the memory categories of interest
-    memory_categories = [
-        "vertex",
-        "control",
-        "exchange",
-        "constants",
-        "always_live",
-        "including_gaps",
-        "excluding_gaps",
-        "not_always_live",
-    ]
+#     for category in memory_categories:
+#         # Get the category from the report and save to CSV
+#         memory = getattr(report.memory, category)
+#         np.savetxt(dir.joinpath(f"{category}_memory.csv"), memory.tiles, delimiter=",")
 
-    for category in memory_categories:
-        # Get the category from the report and save to CSV
-        memory = getattr(report.memory, category)
-        np.savetxt(dir.joinpath(f"{category}_memory.csv"), memory.tiles, delimiter=",")
+# def analyse_profile(benchmark_name: str, app_dir: str) -> str:
+#     """Analyse and output information from a popvision profile.
 
+#     Args:
+#         benchmark_name (str): Name of the benchmark being run
+#         app_dir (str): Application root directory
 
-def analyse_profile(benchmark_name: str, app_dir: str) -> str:
-    """Analyse and output information from a popvision profile.
+#     Returns:
+#         mem_writeout (str): The analysis results from the profile in str format
 
-    Args:
-        benchmark_name (str): Name of the benchmark being run
-        app_dir (str): Application root directory
+#     """
+#     # Get first dir made by popvision (this will be the training report
+#     # in the case of a train + validate run)
+#     report_dir = Path(app_dir).joinpath(benchmark_name + "_profile").resolve()
+#     for path in report_dir.iterdir():
+#         if path.is_dir():
+#             profile = report_dir.joinpath(path, "profile.pop")
+#             break
 
-    Returns:
-        mem_writeout (str): The analysis results from the profile in str format
-    
-    """
-    # Get first dir made by popvision (this will be the training report
-    # in the case of a train + validate run)
-    report_dir = Path(app_dir).joinpath(benchmark_name + "_profile").resolve()
-    for path in report_dir.iterdir():
-        if path.is_dir():
-            profile = report_dir.joinpath(path, "profile.pop")
-            break
-
-    if not profile.is_file():
-        message = "Popvision report not created. Skipping analysis."
-        logger.info(message)
-        return message
-    else:
-        report = reptil.open_report(str(profile))
-        # Analyse and log the profile, Append results to stdout
-        mem_writeout = log_profile_summary(report=report)
-        # Save more detailed breakdowns to local
-        save_profile_breakdowns(report=report, dir=profile.parent)
-        return mem_writeout
+#     if not profile.is_file():
+#         message = "Popvision report not created. Skipping analysis."
+#         logger.info(message)
+#         return message
+#     else:
+#         report = reptil.open_report(str(profile))
+#         # Analyse and log the profile, Append results to stdout
+#         mem_writeout = log_profile_summary(report=report)
+#         # Save more detailed breakdowns to local
+#         save_profile_breakdowns(report=report, dir=profile.parent)
+#         return mem_writeout

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -214,8 +214,8 @@ def run_benchmark_variant(
     logger.info(f"Total runtime: {total_runtime} seconds")
 
     # Analyse profile data and output to logs
-    if args.profile:
-        output += analyse_profile(variant_name, cwd)
+    # if args.profile:
+    #     output += analyse_profile(variant_name, cwd)
 
     # If process didnt end as expected
     if exitcode:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -18,7 +18,7 @@ from examples_utils.benchmarks.command_utils import formulate_benchmark_command,
 from examples_utils.benchmarks.environment_utils import get_mpinum, merge_environment_variables
 from examples_utils.benchmarks.logging_utils import print_benchmark_summary
 from examples_utils.benchmarks.metrics_utils import derive_metrics, extract_metrics, get_results_for_compile_time
-from examples_utils.benchmarks.profiling_utils import add_profiling_vars, analyse_profile
+from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 
 # Get the module logger
 logger = logging.getLogger()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ cppimport==21.3.7
 filelock
 psutil==5.7.0
 pyyaml==5.4.1
-reptil @ git+ssh://git@phabricator.sourcevertex.net/diffusion/REPTIL/reptil.git@05a7d35441933a7e8e60a0163aa30acbff871f09#egg=reptil


### PR DESCRIPTION
Adding reptil as a dependency broke some GCL tests, as the `package @ URL` format is not handled by all dependency managers, and also reptil requires phabricator access to download, which would is not appropriate for a public facing repository

Removing reptil imports and associated functions. 