### PR TITLE
Removing numpy from profiling imports

### DIFF
--- a/examples_utils/benchmarks/profiling_utils.py
+++ b/examples_utils/benchmarks/profiling_utils.py
@@ -1,5 +1,4 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
-import numpy as np
 import json
 #import reptil
 import logging


### PR DESCRIPTION
removing numpy as its not longer needed, and is not included in requirements.txt here. This now is a possible error case where users do not have a version of numpy available in their environment, or where users build packages with steps before pip is called. 