### PR TITLE
adding compile time uploading to wandb enabled runs

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -140,8 +140,8 @@ def formulate_benchmark_command(
     cmd = benchmark_dict["cmd"].format(**variant_dict)
     cmd = cmd.replace("\n", " ")
 
-    old_cmd = " ".join(cmd.split())
-    logger.info(f"original cmd = '{old_cmd}'")
+    cmd = " ".join(cmd.split())
+    logger.info(f"original cmd = '{cmd}'")
     logger.info(f"Cleaning and modifying command if required...")
 
     # Append application location from yaml to command
@@ -155,9 +155,7 @@ def formulate_benchmark_command(
     if examples_location is None:
         examples_location = Path.home()
     resolved_file = str(Path(Path.home(), benchmark_dict["location"], called_file).resolve())
-
     cmd = cmd.replace(called_file, resolved_file)
-    print(cmd)
 
     if ignore_wandb and "--wandb" in cmd:
         logger.info("Both '--ignore-wandb' and '--wandb' were passed, '--ignore-wandb' "

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -3,6 +3,7 @@ import argparse
 import logging
 import os
 import sys
+import wandb
 from datetime import datetime
 from pathlib import Path
 from time import time
@@ -61,3 +62,29 @@ def print_benchmark_summary(results: dict):
         print("=================== short test summary info ====================\n")
         print("\n".join(summary) + "\n")
         print(f"================ {failed} failed, {passed} passed ===============")
+
+
+def get_wandb_link(stderr):
+    """Get a wandb link from stderr if it exists.
+    """
+
+    wandb_link = None
+    for line in stderr.split("\n"):
+        if "https://wandb.sourcevertex.net" in line and "/runs/" in line:
+            wandb_link = "https:/" + line.split("https:/")[1]
+            wandb_link = wandb_link.replace("\n", "")
+    
+    return wandb_link
+
+
+def upload_compile_time(wandb_link, results):
+    """Upload compile time results to a wandb link
+    """
+
+    # Re-initialise link to allow uploading again
+    link_parts = wandb_link.split("/")
+    run = wandb.init(
+        project=link_parts[-3], id=link_parts[-1], resume="allow"
+    )
+
+    run.log({"Total compile time": results["total_compiling_time"]["mean"]})

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -73,7 +73,7 @@ def get_wandb_link(stderr):
         if "https://wandb.sourcevertex.net" in line and "/runs/" in line:
             wandb_link = "https:/" + line.split("https:/")[1]
             wandb_link = wandb_link.replace("\n", "")
-    
+
     return wandb_link
 
 
@@ -83,8 +83,6 @@ def upload_compile_time(wandb_link, results):
 
     # Re-initialise link to allow uploading again
     link_parts = wandb_link.split("/")
-    run = wandb.init(
-        project=link_parts[-3], id=link_parts[-1], resume="allow"
-    )
+    run = wandb.init(project=link_parts[-3], id=link_parts[-1], resume="allow")
 
     run.log({"Total compile time": results["total_compiling_time"]["mean"]})

--- a/examples_utils/benchmarks/metrics_utils.py
+++ b/examples_utils/benchmarks/metrics_utils.py
@@ -193,11 +193,15 @@ def get_results_for_compile_time(results: dict, stderr: str, exitcode: int) -> d
     # Calculate overall start/end times from all instances
     results = get_overall_compile_times(results, results_per_inst, exitcode)
 
-    # Log compile time
+    # Log compile time and add to stderr
     is_recording_legit = isinstance(results["total_compiling_time"]["mean"], float)
     if is_recording_legit:
         printable_time = round(results["total_compiling_time"]["mean"], 2)
-    logger.info(f"   Total compile time: {printable_time if is_recording_legit else 'ERROR'} seconds")
+        compile_time_output = f"   Total compile time: {printable_time} seconds"
+    else:
+        compile_time_output = f"   Total compile time: ERROR"
+    
+    logger.info(compile_time_output)
 
     return results
 

--- a/examples_utils/benchmarks/metrics_utils.py
+++ b/examples_utils/benchmarks/metrics_utils.py
@@ -200,7 +200,7 @@ def get_results_for_compile_time(results: dict, stderr: str, exitcode: int) -> d
         compile_time_output = f"   Total compile time: {printable_time} seconds"
     else:
         compile_time_output = f"   Total compile time: ERROR"
-    
+
     logger.info(compile_time_output)
 
     return results

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -16,7 +16,7 @@ import yaml
 
 from examples_utils.benchmarks.command_utils import formulate_benchmark_command, get_benchmark_variants
 from examples_utils.benchmarks.environment_utils import get_mpinum, merge_environment_variables
-from examples_utils.benchmarks.logging_utils import print_benchmark_summary
+from examples_utils.benchmarks.logging_utils import print_benchmark_summary, get_wandb_link, upload_compile_time
 from examples_utils.benchmarks.metrics_utils import derive_metrics, extract_metrics, get_results_for_compile_time
 from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 
@@ -227,11 +227,6 @@ def run_benchmark_variant(
         logger.critical(err)
         sys.exit(exitcode)
 
-    with open(outlog_path, "w") as f:
-        f.write(output)
-    with open(errlog_path, "w") as f:
-        f.write(err)
-
     # Get 'data' metrics, these are metrics scraped from the log
     results, extraction_failure = extract_metrics(
         benchmark_dict.get("data", {}),
@@ -254,6 +249,16 @@ def run_benchmark_variant(
         err,
         exitcode,
     )
+
+    # Add compile time results to wandb link, if wandb was enabled
+    wandb_link = get_wandb_link(err)
+    if wandb_link is not None:
+        upload_compile_time(wandb_link, results)
+
+    with open(outlog_path, "w") as f:
+        f.write(output)
+    with open(errlog_path, "w") as f:
+        f.write(err)
 
     # Store metrics/details for this variant and return
     variant_result = {

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ cppimport==21.3.7
 filelock
 psutil==5.7.0
 pyyaml==5.4.1
+wandb==0.12.1


### PR DESCRIPTION
This change adds wandb tracking of compile time for all benchmarks run by this benchmarking sub-module (with wandb enabled in the benchmark itself), via run re-initialisation and uploading.

This solves an issue addressed by product management and CE teams, where compile times for benchmarks are not easy/possible to find from wandb logs.