### PR TITLE
Importing and using wandb only if app requires

### DIFF
--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -7,7 +7,6 @@ from datetime import datetime
 from pathlib import Path
 from time import time
 
-
 # Attempt to import wandb silently, if app being benchmarked has required it
 wandb_available = True
 try:

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -3,10 +3,18 @@ import argparse
 import logging
 import os
 import sys
-import wandb
 from datetime import datetime
 from pathlib import Path
 from time import time
+
+
+# Attempt to import wandb silently, if app being benchmarked has required it
+wandb_available = True
+try:
+    import wandb
+except:
+    wandb_available = False
+os.environ["BENCHMARKING_WANDB_AVAILABLE"] = str(wandb_available)
 
 
 def configure_logger(args: argparse.ArgumentParser):

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -8,12 +8,11 @@ from pathlib import Path
 from time import time
 
 # Attempt to import wandb silently, if app being benchmarked has required it
-wandb_available = True
+WANDB_AVAILABLE = True
 try:
     import wandb
 except:
-    wandb_available = False
-os.environ["BENCHMARKING_WANDB_AVAILABLE"] = str(wandb_available)
+    WANDB_AVAILABLE = False
 
 
 def configure_logger(args: argparse.ArgumentParser):

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -16,7 +16,7 @@ import yaml
 
 from examples_utils.benchmarks.command_utils import formulate_benchmark_command, get_benchmark_variants
 from examples_utils.benchmarks.environment_utils import get_mpinum, merge_environment_variables
-from examples_utils.benchmarks.logging_utils import print_benchmark_summary, get_wandb_link, upload_compile_time
+from examples_utils.benchmarks.logging_utils import print_benchmark_summary, get_wandb_link, upload_compile_time, WANDB_AVAILABLE
 from examples_utils.benchmarks.metrics_utils import derive_metrics, extract_metrics, get_results_for_compile_time
 from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 
@@ -251,7 +251,7 @@ def run_benchmark_variant(
     )
 
     # Add compile time results to wandb link, if wandb was imported by app
-    if os.environ.get("BENCHMARKING_WANDB_AVAILABLE") == "True":
+    if WANDB_AVAILABLE == "True":
         wandb_link = get_wandb_link(err)
         if wandb_link is not None:
             upload_compile_time(wandb_link, results)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -250,10 +250,11 @@ def run_benchmark_variant(
         exitcode,
     )
 
-    # Add compile time results to wandb link, if wandb was enabled
-    wandb_link = get_wandb_link(err)
-    if wandb_link is not None:
-        upload_compile_time(wandb_link, results)
+    # Add compile time results to wandb link, if wandb was imported by app
+    if os.environ.get("BENCHMARKING_WANDB_AVAILABLE") == "True":
+        wandb_link = get_wandb_link(err)
+        if wandb_link is not None:
+            upload_compile_time(wandb_link, results)
 
     with open(outlog_path, "w") as f:
         f.write(output)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -251,7 +251,7 @@ def run_benchmark_variant(
     )
 
     # Add compile time results to wandb link, if wandb was imported by app
-    if WANDB_AVAILABLE == "True":
+    if WANDB_AVAILABLE == True:
         wandb_link = get_wandb_link(err)
         if wandb_link is not None:
             upload_compile_time(wandb_link, results)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -251,7 +251,7 @@ def run_benchmark_variant(
     )
 
     # Add compile time results to wandb link, if wandb was imported by app
-    if WANDB_AVAILABLE == True:
+    if WANDB_AVAILABLE:
         wandb_link = get_wandb_link(err)
         if wandb_link is not None:
             upload_compile_time(wandb_link, results)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ cppimport==21.3.7
 filelock
 psutil==5.7.0
 pyyaml==5.4.1
-wandb==0.12.1


### PR DESCRIPTION
removes wandb as a requirement for examples_utils (benchmarking) and now instead checks and relies on the app being benchmarked to import wandb. 

This prevents potential version/env conflicts and polluting environments setup for specific applications