### PR TITLE
Adding ce benchmarking features

### DIFF
--- a/examples_utils/benchmarks/README.md
+++ b/examples_utils/benchmarks/README.md
@@ -57,12 +57,15 @@ Points to note are:
 - When profiling, the popvision profile is saved in the current working directory (this will be the application directory where the benchmarks are being run) and `POPLAR_ENGINE_OPTIONS` is given: `"autoReport.all": "true"` and `"autoReport.outputSerializedGraph": "false"`. This is to enable all standard profiling functionality but avoiding making the profile too large.
 
 ## Changelong
-07/04/22 - Initial commits
-28/04/22 - Post-review cleanup and documenting
+07/04 - Initial commits
+28/04 - Post-review cleanup and documenting
 03/05 - Modularising and adding to examples_utils
 17/05 - Added profiling
+22/06 - Adding robust pathfidning for ymls/scripts
+27/06 - Adding wandb compile time updating
 
 ## Future work plans
-- Adding more functionality from ce_benchmarks/test automation repos to run_benchmarks
-- Supporting a full move of benchmarking from ce_benchmarks to applications repositories
-- Moving some app-specific infrastructure from ce_benchmarking/test automation repos to examples_utils
+- Adding `--ignore-errors` arg to avoid terminating with a failure in one of multiple benchmarks
+- Support for pytest benchmarks
+- CSV report generation from results of multiple benchmarks
+- Adding profile analysis to profiling 

--- a/examples_utils/benchmarks/README.md
+++ b/examples_utils/benchmarks/README.md
@@ -63,9 +63,9 @@ Points to note are:
 17/05 - Added profiling
 22/06 - Adding robust pathfidning for ymls/scripts
 27/06 - Adding wandb compile time updating
+06/07 - Adding more functionality from internal benchmarking tools
 
 ## Future work plans
-- Adding `--ignore-errors` arg to avoid terminating with a failure in one of multiple benchmarks
 - Support for pytest benchmarks
 - CSV report generation from results of multiple benchmarks
 - Adding profile analysis to profiling 

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -154,7 +154,7 @@ def formulate_benchmark_command(
 
     if examples_location is None:
         examples_location = Path.home()
-    resolved_file = str(Path(Path.home(), benchmark_dict["location"], called_file).resolve())
+    resolved_file = str(Path(examples_location, benchmark_dict["location"], called_file).resolve())
     cmd = cmd.replace(called_file, resolved_file)
 
     if ignore_wandb and "--wandb" in cmd:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -225,7 +225,8 @@ def run_benchmark_variant(
         logger.critical(output)
         logger.critical("STDERR:")
         logger.critical(err)
-        sys.exit(exitcode)
+        if not args.ignore_errors:
+            sys.exit(exitcode)
 
     # Get 'data' metrics, these are metrics scraped from the log
     results, extraction_failure = extract_metrics(
@@ -445,6 +446,11 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--examples-location",
         default=None,
-        type=int,
+        type=str,
         help="Location of the examples directory, defaults to user dir.",
+    )
+    parser.add_argument(
+        "--ignore-errors",
+        action="store_true",
+        help="Do not stop on an error",
     )


### PR DESCRIPTION
- Fixing `--examples-path` arg - previously was not actually affecting the path being looked at
- Adding `--ignore-errors` to allow later benchmarks in a spec or list to proceed without exiting on error