### PR TITLE
Benchmark fixes + updates

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -110,7 +110,7 @@ def get_benchmark_variants(benchmark_name: str, benchmark_dict: dict) -> list:
 def formulate_benchmark_command(
         benchmark_dict: dict,
         variant_dict: dict,
-        ignore_wandb: bool,
+        allow_wandb: bool,
         compile_only: bool,
         examples_location: str = None,
 ) -> str:
@@ -121,7 +121,7 @@ def formulate_benchmark_command(
             pre-formating to fill in variables
         variant_dict (dict): Variant specification, containing all the actual
             values of the variables to be used to construct this command
-        ignore_wandb (bool): Whether or not to ignore wandb flags passed to the
+        allow_wandb (bool): Whether or not to allow wandb flags passed to the
             original command
         compile_only (bool): Whether or not to pass a `--compile-only` flag to
             the command. NOTE: This will only work if the app being run itself
@@ -157,9 +157,11 @@ def formulate_benchmark_command(
     resolved_file = str(Path(examples_location, benchmark_dict["location"], called_file).resolve())
     cmd = cmd.replace(called_file, resolved_file)
 
-    if ignore_wandb and "--wandb" in cmd:
-        logger.info("Both '--ignore-wandb' and '--wandb' were passed, '--ignore-wandb' "
-                    "is overriding, purging '--wandb' from command.")
+    if not allow_wandb and "--wandb" in cmd:
+        logger.info("'--allow-wandb' was not passed, however '--wandb' is an "
+                    "argument provided to the benchmark. The default value of "
+                    "'--allow-wandb' (False) is overriding, purging '--wandb' "
+                    " from command.")
         cmd = cmd.replace("--wandb", "")
 
     if compile_only:

--- a/examples_utils/benchmarks/metrics_utils.py
+++ b/examples_utils/benchmarks/metrics_utils.py
@@ -243,7 +243,7 @@ def extract_metrics(extraction_config: dict, log: str, exitcode: int, num_replic
             logger.error(f"  '{name}' had non-zero exitcode: '{str(exitcode)}'")
         # Check results sufficient for 'skip'
         elif len(all_results) <= metric_spec["skip"]:
-            logger.error(f"  '{name}' has less results than the skip value: " f"'{metric_spec['skip']}'")
+            logger.error(f"  '{name}' has less results than the skip value: '{metric_spec['skip']}'")
 
         # Post-process the results
         else:
@@ -343,7 +343,7 @@ def derive_metrics(
                 result = eval(expression)
                 logger.info(f"   '{name}' = '{str(result)}'")
             except:
-                logger.error(f"   ERROR: '{name}' = 'derived' expression: " f"'{expression}' excepted")
+                logger.error(f"   ERROR: '{name}' = 'derived' expression: '{expression}' excepted")
 
         results[name] = {config["reduction_type"]: result}
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -368,8 +368,7 @@ def run_benchmarks(args: argparse.ArgumentParser):
         for benchmark_name in args.benchmark:
             # Check if this benchmark exists
             if benchmark_name not in list(spec.keys()):
-                logger.error(f"Benchmark {benchmark_name} not found in "
-                             "provided spec files, exiting.")
+                logger.error(f"Benchmark {benchmark_name} not found in " "provided spec files, exiting.")
                 sys.exit(1)
 
             # Do not treat the common options or similar specifications as
@@ -550,5 +549,10 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--include-convergence",
         action="store_true",
-        help="Include convergence tests (name ending in '_conv') in the set of benchmarks being run. This only has any effect if convergence tests would be run anyway i.e. if there are convergence benchmarks in the yaml file provided in '--spec' or if the convergence test required is named explicitly in '--benchmarks'.",
+        help=("Include convergence tests (name ending in '_conv') in the set "
+              "of benchmarks being run. This only has any effect if "
+              "convergence tests would be run anyway i.e. if there are "
+              "convergence benchmarks in the yaml file provided in '--spec' or "
+              "if the convergence test required is named explicitly in "
+              "'--benchmarks'."),
     )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cppimport==21.3.7
 filelock
-psutil==5.7.0
-pyyaml==5.4.1
+psutil>=5.7.0
+pyyaml>=5.4.1


### PR DESCRIPTION
1) Fixes a bug with requirements where pinned versions here would cause issues with some applications in ubuntu 20.04

2) Adds various fixes and updates:
- Benchmarks are run in order now
- No dataset dir checks for synthetic/generated data benchmarks
- Wandb disabled by default (not assuming users should have this)
- Excluding convergence tests by default (needs to be specially enabled now)