### PR TITLE
Upgrading key dir pathfinding capabilities

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -157,6 +157,10 @@ def formulate_benchmark_command(
     resolved_file = str(Path(called_file).resolve())
     cmd = cmd.replace(called_file, resolved_file)
 
+    # Change cwd to where the resolved file is, in case benchmarks file is not
+    # in same dir as called python file
+    os.chdir(Path(resolved_file).parent)
+
     if not args.allow_wandb and "--wandb" in cmd:
         logger.info("'--allow-wandb' was not passed, however '--wandb' is an "
                     "argument provided to the benchmark. The default value of "

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def create_variants(benchmark_dict: dict) -> list:
+def create_variants(benchmark_name: str, benchmark_dict: dict) -> list:
     """Create all variants from a benchmark entry.
 
     Note:
@@ -42,6 +42,7 @@ def create_variants(benchmark_dict: dict) -> list:
         apply.
 
     Args:
+        benchmark_name (str): Benchmarks name as given in the spec yaml file
         benchmark_dict (dict): benchmark entry itself in yaml file
 
     Returns:
@@ -78,7 +79,14 @@ def create_variants(benchmark_dict: dict) -> list:
                             variants.append(x)
 
         else:
-            raise ValueError("'parameters' defined are neither a list nor a dict")
+            err = (f"In {benchmark_name} in {benchmark_dict['benchmark_path']},"
+                   " the 'parameters' are defined in neither a list style or "
+                   "a dict style. They must be defined as one of the two "
+                   "(using a comma seperated list, optionally surrounded by "
+                   "square brackets, or as a dict, surrounded by curly "
+                   "brackets).")
+            logger.error(err)
+            raise ValueError(err)
 
     return variants
 
@@ -96,7 +104,7 @@ def get_benchmark_variants(benchmark_name: str, benchmark_dict: dict) -> list:
     """
 
     # Create variants from benchmark
-    variant_names = create_variants(benchmark_dict)
+    variant_names = create_variants(benchmark_name, benchmark_dict)
 
     variants = []
     for variant in variant_names:
@@ -146,7 +154,7 @@ def formulate_benchmark_command(
         py_name = "python"
     called_file = cmd_parts[cmd_parts.index(py_name) + 1]
 
-    resolved_file = str(Path(args.examples_location, benchmark_dict["location"], called_file).resolve())
+    resolved_file = str(Path(called_file).resolve())
     cmd = cmd.replace(called_file, resolved_file)
 
     if not args.allow_wandb and "--wandb" in cmd:

--- a/examples_utils/benchmarks/distributed_utils.py
+++ b/examples_utils/benchmarks/distributed_utils.py
@@ -51,13 +51,7 @@ def setup_distributed_filesystems(args: ArgumentParser, poprun_hostnames: list):
     
     """
 
-    # Find where examples dir could be
-    if Path(args.examples_location, "public_examples").is_dir():
-        examples_path = args.examples_location + "/public_examples"
-    else:
-        examples_path = args.examples_location + "/examples"
-
-    dirs_to_sync = [examples_path, args.sdk_path, args.venv_path]
+    dirs_to_sync = [args.examples_path, args.sdk_path, args.venv_path]
 
     with open(Path(args.log_dir, "host_setup.log"), "w") as output_stream:
         # Ensure this host can direct the others
@@ -89,13 +83,7 @@ def remove_distributed_filesystems(args: ArgumentParser, poprun_hostnames: list)
 
     """
 
-    # Find where examples dir could be
-    if Path(args.examples_location, "public_examples").is_dir():
-        examples_path = args.examples_location + "/public_examples"
-    else:
-        examples_path = args.examples_location + "/examples"
-
-    dirs_to_remove = [examples_path, args.sdk_path, args.venv_path]
+    dirs_to_remove = [args.examples_path, args.sdk_path, args.venv_path]
 
     with open(Path(args.log_dir, "host_teardown.log"), "w") as output_stream:
         for hostname, dirname in itertools.product(poprun_hostnames, dirs_to_remove):

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -3,6 +3,8 @@ import copy
 import logging
 import os
 import re
+from argparse import ArgumentParser
+from pathlib import Path
 
 # Get the module logger
 logger = logging.getLogger(__name__)
@@ -26,6 +28,55 @@ def get_mpinum(command: str) -> int:
         mpinum = 1
 
     return mpinum
+
+
+def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:
+    """Infer paths to key directories based on argument and environment info.
+
+    Args:
+        args (ArgumentParser): The arguments passed to this benchmarking run
+        benchmark_dict (dict): The parameters for a particular benchmark
+    
+    Returns:
+        args (ArgumentParser): args, but with additional paths attributes added
+    
+    """
+
+    spec_path = benchmark_dict["benchmark_path"]
+    print(spec_path)
+    offset = 4
+    # If the benchmarks.yml file is in train/infer the application root dir
+    if ("train" in spec_path) or ("infer" in spec_path):
+        offset += 1
+
+    # Split path to benchmark.yml, find what the dir contatining all examples
+    # is called, and add it back together
+    args.examples_path = str(Path("/".join(spec_path.split("/")[:-offset])).resolve())
+
+    # Find based on the required environment variable when a SDK is enabled
+    sdk_path = os.getenv("POPLAR_SDK_ENABLED")
+    if sdk_path is None:
+        err = ("It appears that a poplar SDK has not been enabled, determined "
+               "by 'POPLAR_SDK_ENABLED' environment variable not detected in "
+               "this environment. Please make sure the SDK is enabled in this "
+               "environment (use 'source' when enabling/activating).")
+        logger.error(err)
+        raise EnvironmentError(err)
+    args.sdk_path = str(Path(sdk_path).parents[1].resolve())
+    
+    # Find based on the required environment variable when a venv is activated
+    venv_path = os.getenv("VIRTUAL_ENV")
+    if venv_path is None:
+        err = ("It appears that a python virtual environment has not been "
+               "activated, determined by 'VIRTUAL_ENV' environment variable "
+               "not detected in this environment. Please make sure the python "
+               "virtual environment is activate in this environment (use "
+               "'source' when enabling/activating).")
+        logger.error(err)
+        raise EnvironmentError(err)
+    args.venv_path = str(Path(venv_path).parents[1].resolve())
+
+    return args
 
 
 def merge_environment_variables(new_env: dict, benchmark_spec: dict) -> dict:

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -63,7 +63,7 @@ def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:
         logger.error(err)
         raise EnvironmentError(err)
     args.sdk_path = str(Path(sdk_path).parents[1].resolve())
-    
+
     # Find based on the required environment variable when a venv is activated
     venv_path = os.getenv("VIRTUAL_ENV")
     if venv_path is None:

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -43,7 +43,6 @@ def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:
     """
 
     spec_path = benchmark_dict["benchmark_path"]
-    print(spec_path)
     offset = 4
     # If the benchmarks.yml file is in train/infer the application root dir
     if ("train" in spec_path) or ("infer" in spec_path):

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -27,6 +27,7 @@ from examples_utils.benchmarks.distributed_utils import (
 )
 from examples_utils.benchmarks.environment_utils import (
     get_mpinum,
+    infer_paths,
     merge_environment_variables,
 )
 from examples_utils.benchmarks.logging_utils import (
@@ -221,7 +222,11 @@ def run_benchmark_variant(
     # environment variables
     env = merge_environment_variables(new_env, benchmark_dict)
 
+    # Infer examples, SDK and venv path for this benchmark
+    args = infer_paths(args, benchmark_dict)
+
     logger.info(f"Datasets directory: '{os.getenv('DATASETS_DIR')}'")
+
     # Detect if benchmark requires instances running (not just compiling) on
     # other hosts, and then prepare hosts
     poprun_hostnames = get_poprun_hosts(cmd)
@@ -362,10 +367,12 @@ def run_benchmarks(args: argparse.ArgumentParser):
 
         # Only check explicitily listed benchmarks if provided
         if args.benchmark is None:
-            args.benchmark = list(spec.keys())
+            benchmarks_list = list(spec.keys())
+        else:
+            benchmarks_list = args.benchmark
 
         variant_dictionary = OrderedDict()
-        for benchmark_name in args.benchmark:
+        for benchmark_name in benchmarks_list:
             # Check if this benchmark exists
             if benchmark_name not in list(spec.keys()):
                 err = (f"Benchmark {benchmark_name} not found in any of the provided spec files, exiting.")
@@ -379,7 +386,9 @@ def run_benchmarks(args: argparse.ArgumentParser):
 
             # Skip convergence tests by default unless --include-convergence
             # is provided, or they are explicitly named in --benchmarks
-            if ("_conv" in benchmark_name) and (not args.include_convergence):
+            if ((args.benchmark is None) and
+                ("_conv" in benchmark_name) and
+                (not args.include_convergence)):
                 continue
 
             # Enforce DATASETS_DIR set only if this benchmark needs real data
@@ -485,11 +494,14 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
         help="Enable compile only options in compatible models",
     )
     parser.add_argument(
-        "--examples-location",
-        default=str(Path.home()),
-        type=str,
-        help=("Parent dir of the examples directory, defaults to the value of "
-              "$HOME."),
+        "--include-convergence",
+        action="store_true",
+        help=("Include convergence tests (name ending in '_conv') in the set "
+              "of benchmarks being run. This only has any effect if "
+              "convergence tests would be run anyway i.e. if there are "
+              "convergence benchmarks in the yaml file provided in '--spec' or "
+              "if the convergence test required is named explicitly in "
+              "'--benchmarks'."),
     )
     parser.add_argument(
         "--ignore-errors",
@@ -530,31 +542,8 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
               "Defaults to the parent dir of the benchmarks.yml file."),
     )
     parser.add_argument(
-        "--sdk-path",
-        default=str(Path.home().joinpath("sdks")),
-        type=str,
-        help="path of the PoplarSDK directory, defaults to '~/sdks'.",
-    )
-    parser.add_argument(
         "--timeout",
         default=None,
         type=int,
         help="Maximum time allowed for any benchmark/variant (in seconds)",
-    )
-    parser.add_argument(
-        "--venv-path",
-        default=str(Path.home().joinpath("venvs")),
-        type=str,
-        help=("Path to the python virtual environment (venv used for the "
-              "PoplarSDK) directory, defaults to '~/venvs'."),
-    )
-    parser.add_argument(
-        "--include-convergence",
-        action="store_true",
-        help=("Include convergence tests (name ending in '_conv') in the set "
-              "of benchmarks being run. This only has any effect if "
-              "convergence tests would be run anyway i.e. if there are "
-              "convergence benchmarks in the yaml file provided in '--spec' or "
-              "if the convergence test required is named explicitly in "
-              "'--benchmarks'."),
     )

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -386,9 +386,7 @@ def run_benchmarks(args: argparse.ArgumentParser):
 
             # Skip convergence tests by default unless --include-convergence
             # is provided, or they are explicitly named in --benchmarks
-            if ((args.benchmark is None) and
-                ("_conv" in benchmark_name) and
-                (not args.include_convergence)):
+            if ((args.benchmark is None) and ("_conv" in benchmark_name) and (not args.include_convergence)):
                 continue
 
             # Enforce DATASETS_DIR set only if this benchmark needs real data


### PR DESCRIPTION
Previously, to determine the path to the applications root directory (examples or public_examples etc.) the user had to supply an argument and a `location` parameter was required in benchmarks.yml files. This update removes that need and instead infers the actual, currently used applications root dir from the benchmarks.yml file being specified instead. 

SDK and venv paths are also now inferred from environment variables which must be set when SDK is enabled and venv activated. 

Tested locally.