### PR TITLE
Poprun ews update

### DIFF
--- a/examples_utils/benchmarks/README.md
+++ b/examples_utils/benchmarks/README.md
@@ -37,22 +37,11 @@ Points to note are:
 - When profiling, the popvision profile is saved in the current working directory (this will be the application directory where the benchmarks are being run) and `POPLAR_ENGINE_OPTIONS` is given: `"autoReport.all": "true"` and `"autoReport.outputSerializedGraph": "false"`. This is to enable all standard profiling functionality but avoiding making the profile too large.
 
 ## Changelog
-- 07/04 - Initial commits
-- 28/04 - Post-review cleanup and documenting
-- 03/05 - Modularising and adding to examples_utils
-- 17/05 - Added profiling
-- 22/06 - Adding robust pathfidning for ymls/scripts
-- 27/06 - Compile times are now logged to wandb runs where applicable
-- 06/07 - Adding more functionality from internal benchmarking tools
-- 21/07 - Results now stored at the end of benchmarking in CSV and JSON formats
-- 30/07 - Multi-host + Multi-instance benchmarks can now be run with this
+Please see the changelog file for a full history.
 
 ## Future work plans
 - Support for pytest benchmarks
 - Adding profile analysis to profiling
-- Remove wandb by default for external users
-- Filter out convergence testing by default
-- Fix the order in which benchmarks are run to the order they are defined in benchmark yaml files
 - Slack integration
 - Adding checkpoint uploading and offline wandb capabilities
 - Creating documentation

--- a/examples_utils/benchmarks/benchmark_creation_guide.md
+++ b/examples_utils/benchmarks/benchmark_creation_guide.md
@@ -54,13 +54,6 @@ output:
     - `value`: Used when only one instance of that metric will exist in the logs, do no postprocessing on it.
 - The output section will be used when creating a `results.csv` file, where the mapping here will determine how the string that is mapped to by the metric defined will be used as a header in that file
 
-### <ins>Location</ins>
-```
-location:
-    public_examples/applications/pytorch/dino/
-```
-This should be the root dir for the application where `requirements.txt`, the makefile and the scripts required can be found.
-
 ### <ins>Environment</ins>
 ```
 env:
@@ -180,7 +173,6 @@ And so its clear that with long parameter names or values, the variant name (Whi
 Rather than repeating the same fields with the same values in the case where all/multiple benchmarks share them, you can create a commonly used section that can be referenced in benchmarks. For example:
 ```
 common_options: &common_options
-  location: public_examples/applications/pytorch/cnns/train
   env:
     POPLAR_ENGINE_OPTIONS: '{"opt.enableMultiAccessCopies":"false"}'
     PYTORCH_CACHE_DIR: "./pt_cache/"

--- a/examples_utils/benchmarks/changelog.md
+++ b/examples_utils/benchmarks/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+- 07/04 - Initial commits
+- 28/04 - Post-review cleanup and documenting
+- 03/05 - Modularising and adding to examples_utils
+- 17/05 - Added profiling
+- 22/06 - Adding robust pathfidning for ymls/scripts
+- 27/06 - Compile times are now logged to wandb runs where applicable
+- 06/07 - Adding more functionality from internal benchmarking tools
+- 21/07 - Results now stored at the end of benchmarking in CSV and JSON formats
+- 30/07 - Multi-host + Multi-instance benchmarks can now be run with this
+- 02/08 - Benchmark ordering, wandb default behaviour and other minor fixes
+- 04/08 - More robust pathfinding capabilities to avoid excessive user input
+- 09/08 - Adding a poprun early warning system to demistify poprun errors, and other small QoL fixes 

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -70,7 +70,7 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str) -> str:
                   "    CLUSTER = Name of the Virtual IPU cluster. Can be found "
                   "with 'vipu list partition'.\n"
                   "    TCP_IF_INCLUDE = The range of network interfaces "
-                  "available to use for poprun to communicate between.\n"
+                  "available to use for poprun to communicate between hosts.\n"
                   "    VIPU_CLI_API_HOST = The IP address/name of the HOST "
                   "where the Virtual IPU server is running.\n")
             raise EnvironmentError(err)

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -56,17 +56,14 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str):
 
     # Check if any of the poprun env vars are required but not set
     missing_env_vars = [
-        env_var for env_var in POPRUN_VARS.keys()
-        if f"${env_var}" in cmd and os.getenv(env_var) is None
+        env_var for env_var in POPRUN_VARS.keys() if f"${env_var}" in cmd and os.getenv(env_var) is None
     ]
     if missing_env_vars:
-        err = (
-            f"{len(missing_env_vars)} environment variables are needed by command"
-            f"{benchmark_name} but are not defined: {missing_env_vars}. Hints: \n"
-        ) + "".join([
-            f"\n\t{missing} : {POPRUN_VARS[missing]}"
-            for missing in missing_env_vars
-        ])
+        err = (f"{len(missing_env_vars)} environment variables are needed by "
+               f"command {benchmark_name} but are not defined: "
+               f"{missing_env_vars}. Hints: \n")
+        err += "".join([f"\n\t{missing} : {POPRUN_VARS[missing]}" for missing in missing_env_vars])
+
         logger.error(err)
         raise EnvironmentError(err)
 

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -55,14 +55,20 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str):
     """
 
     # Check if any of the poprun env vars are required but not set
-    for env_var, help_msg in POPRUN_VARS.items():
-        if f"${env_var}" in cmd and os.getenv(env_var) is None:
-            err = (f"Environment variable {env_var} is a value passed to an "
-                   f"argument in {benchmark_name}, but has not been set in "
-                   f"your environment.\nHint: {env_var} = {help_msg}")
-            logger.error(err)
-
-            raise EnvironmentError(err)
+    missing_env_vars = [
+        env_var for env_var in POPRUN_VARS.keys()
+        if f"${env_var}" in cmd and os.getenv(env_var) is None
+    ]
+    if missing_env_vars:
+        err = (
+            f"{len(missing_env_vars)} environment variables are needed by command"
+            f"{benchmark_name} but are not defined: {missing_env_vars}. Hints: \n"
+        ) + "".join([
+            f"\n\t{missing} : {POPRUN_VARS[missing]}"
+            for missing in missing_env_vars
+        ])
+        logger.error(err)
+        raise EnvironmentError(err)
 
 
 def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -11,16 +11,17 @@ logger = logging.getLogger(__name__)
 
 POPRUN_VARS = {
     "HOSTS": ("Comma seperated list of IP addresses/names of the machines you "
-        "want to run on. Try to copy across ssh-keys before attempting if "
-        "possible. e.g. 10.1.3.101,10.1.3.102,... or lr17-1,lr17-2,..."),
+              "want to run on. Try to copy across ssh-keys before attempting "
+              "if possible. e.g. 10.1.3.101,10.1.3.102,... or "
+              "lr17-1,lr17-2,..."),
     "PARTITION": ("Name of the Virtual IPU partition. Can be found with "
-        "'vipu list partitions'."),
+                  "'vipu list partitions'."),
     "CLUSTER": ("Name of the Virtual IPU cluster. Can be found with 'vipu "
-        "list partition'."),
+                "list partition'."),
     "TCP_IF_INCLUDE": ("The range of network interfaces available to use for "
-        "poprun to communicate between hosts."),
-    "VIPU_CLI_API_HOST": ("The IP address/name of the HOST where the Virtual "
-        "IPU server is running."),
+                       "poprun to communicate between hosts."),
+    "VIPU_CLI_API_HOST": ("The IP address/name of the HOST where the virtual "
+                          "IPU server is running."),
 }
 
 

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -11,6 +11,7 @@ logger = logging.getLogger(__name__)
 
 POPRUN_VARS = ["HOSTS", "PARTITION", "CLUSTER", "TCP_IF_INCLUDE", "VIPU_CLI_API_HOST"]
 
+
 def get_mpinum(command: str) -> int:
     """Get num replicas (mpinum) from the cmd.
 
@@ -37,7 +38,7 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str) -> str:
     """
     # Python call is guarunteed to exist
     using_python3 = "python3" in cmd
-    if using_python3 :
+    if using_python3:
         poprun_call, python_call = cmd.split("python3")
     else:
         poprun_call, python_call = cmd.split("python")
@@ -45,11 +46,8 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str) -> str:
     # Check if $IPUOF_VIPU_API_PARTITION_ID is asked for (incorrect name),
     # and replace this with $PARTITION (evaluated or not)
     if "$IPUOF_VIPU_API_PARTITION_ID" in poprun_call:
-        poprun_call = poprun_call.replace(
-            "$IPUOF_VIPU_API_PARTITION_ID",
-            os.getenv("PARTITION", "$PARTITION")
-        )
-    
+        poprun_call = poprun_call.replace("$IPUOF_VIPU_API_PARTITION_ID", os.getenv("PARTITION", "$PARTITION"))
+
     python_call_prefix = "python"
     if using_python3: python_call_prefix += "3"
     cmd = poprun_call + python_call_prefix + python_call
@@ -78,6 +76,7 @@ def check_poprun_env_variables(benchmark_name: str, cmd: str) -> str:
             raise EnvironmentError(err)
 
     return cmd
+
 
 def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:
     """Infer paths to key directories based on argument and environment info.

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -194,10 +194,6 @@ def run_benchmark_variant(
     # Create the actual command for the variant
     variant_command = formulate_benchmark_command(benchmark_dict, variant_dict, args)
 
-    # Check if benchmark calls poprun and might require some env variables,
-    # and modify if needs be
-    check_poprun_env_variables(benchmark_name, variant_command)
-
     # Expand any environment variables in the command and split the command
     # into a list, respecting things like quotes, like the shell would
     cmd = shlex.split(os.path.expandvars(variant_command))
@@ -418,6 +414,10 @@ def run_benchmarks(args: argparse.ArgumentParser):
             err = "No valid benchmarks selected"
             logger.error(err)
             raise ValueError(err)
+
+        # Early check for poprun calls that might require some env variables
+        for benchmark_name in variant_dictionary:
+            check_poprun_env_variables(benchmark_name, spec[benchmark_name]["cmd"])
 
         # Run each variant
         for benchmark_name in variant_dictionary:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -368,9 +368,9 @@ def run_benchmarks(args: argparse.ArgumentParser):
     results = {}
     output_log_path = Path(args.log_dir, "output.log")
     with open(output_log_path, "w", buffering=1) as listener:
-        print("\n" + "#"*80)
+        print("\n" + "#" * 80)
         logger.info(f"Logs at: {output_log_path}")
-        print("#"*80 + "\n")
+        print("#" * 80 + "\n")
 
         # Only check explicitily listed benchmarks if provided
         if args.benchmark is None:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -27,6 +27,7 @@ from examples_utils.benchmarks.distributed_utils import (
 )
 from examples_utils.benchmarks.environment_utils import (
     get_mpinum,
+    check_poprun_env_variables,
     infer_paths,
     merge_environment_variables,
 )
@@ -192,6 +193,10 @@ def run_benchmark_variant(
 
     # Create the actual command for the variant
     variant_command = formulate_benchmark_command(benchmark_dict, variant_dict, args)
+
+    # Check if benchmark calls poprun and might require some env variables,
+    # and modify if needs be
+    variant_command = check_poprun_env_variables(benchmark_name, variant_command)
 
     # Expand any environment variables in the command and split the command
     # into a list, respecting things like quotes, like the shell would
@@ -363,7 +368,9 @@ def run_benchmarks(args: argparse.ArgumentParser):
     results = {}
     output_log_path = Path(args.log_dir, "output.log")
     with open(output_log_path, "w", buffering=1) as listener:
+        print("\n" + "#"*80)
         logger.info(f"Logs at: {output_log_path}")
+        print("#"*80 + "\n")
 
         # Only check explicitily listed benchmarks if provided
         if args.benchmark is None:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -196,7 +196,7 @@ def run_benchmark_variant(
 
     # Check if benchmark calls poprun and might require some env variables,
     # and modify if needs be
-    variant_command = check_poprun_env_variables(benchmark_name, variant_command)
+    check_poprun_env_variables(benchmark_name, variant_command)
 
     # Expand any environment variables in the command and split the command
     # into a list, respecting things like quotes, like the shell would


### PR DESCRIPTION
This change adds an EWS (Early warning system) for environment variables required by poprun. For experienced users, poprun errors are fine and workable, but for inexperienced users, poprun errors can be difficult to understand straight away, especially when hidden under (only one, but still...) layers of redirections to logs and outputs. 

This change adds some functionality to check the benchmark command before expanding environment variables to check that those environment variables exist, and then raising a loud, more helpful error at all levels (terminal and logs). In addition, hints are provided, and deprecated/incorrect env variable names are auto-replaced. 

Also fixes to how logging dir is shown to users.

Tested locally on a variety of benchmarks.