### PR TITLE
Platform assessment tools

### DIFF
--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -1,0 +1,36 @@
+import argparse
+import subprocess
+import yaml
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--spec",
+        required=True,
+        type=str,
+        help="Path to yaml file with benchmark spec",
+    )
+    args = parser.parse_args()
+
+    # Run all benchmarks 
+    benchmarks = yaml.load(open(args.spec).read(), Loader=yaml.FullLoader)
+    
+    for name, setup in benchmarks.items():
+        # Formulate command from each benchmark
+        benchmark_cmd = [
+            "source",
+            "./assess_platform.sh",
+            setup["application_name"],
+            setup["benchmark"],
+            setup["build_steps"]
+        ]
+
+        # Run benchmark in a poplar SDK enabled environment
+        with open(f"./{name}.log", "w") as output_stream:
+            subprocess.run(
+                benchmark_cmd,
+                stdout=output_stream,
+                stderr=output_stream,
+            )
+        
+        # Merge CSV outputs into one

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import argparse
 import csv
 import logging
@@ -6,9 +7,7 @@ import sys
 import yaml
 from pathlib import Path
 
-
 HEADER_METRICS = ["benchmark name", "variant_name", "throughput", "latency", "total_compiling_time"]
-
 
 if __name__ == "__main__":
     # Setup logger
@@ -47,7 +46,7 @@ if __name__ == "__main__":
         common_writer = csv.writer(common_file, quoting=csv.QUOTE_ALL)
         common_writer.writerow(HEADER_METRICS)
 
-        # Run all benchmarks 
+        # Run all benchmarks
         for name, setup in benchmarks.items():
             logger.info(f"Running {name}:")
 
@@ -77,7 +76,7 @@ if __name__ == "__main__":
                     stdout=output_stream,
                     stderr=output_stream,
                 )
-            
+
             # Merge CSV outputs from this benchmark into the common CSV
             with open(Path(f"/tmp/{setup['application_name']}_logs/benchmark_results.csv"), "r") as benchmark_csv:
                 # Skip header

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -1,8 +1,9 @@
 import argparse
 import csv
+import logging
 import subprocess
+import sys
 import yaml
-from getpass import getpass
 from pathlib import Path
 
 
@@ -10,6 +11,14 @@ HEADER_METRICS = ["benchmark name", "variant_name", "throughput", "latency", "to
 
 
 if __name__ == "__main__":
+    # Setup logger
+    logger = logging.getLogger()
+    formatter = logging.Formatter("[%(levelname)s] %(asctime)s: %(message)s", "%Y-%m-%d %H:%M:%S")
+    handler = logging.StreamHandler(sys.stderr)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel("INFO")
+
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--spec",
@@ -26,17 +35,26 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     benchmarks = yaml.load(open(args.spec).read(), Loader=yaml.FullLoader)
-    
+    logger.info("Benchmarks found:")
+    for name, _ in benchmarks.items():
+        logger.info(f"\t{name}")
+
     # Write all results into a common CSV
-    with open(Path(args.log_dir, "assessment_results.csv"), "w") as common_file:
+    common_csv_path = Path("./assessment_results.csv").resolve()
+    logger.info(f"Saving all results into {str(common_csv_path)}")
+    with open(common_csv_path, "w") as common_file:
         # Use a fixed set of headers
         common_writer = csv.writer(common_file, quoting=csv.QUOTE_ALL)
         common_writer.writerow(HEADER_METRICS)
 
         # Run all benchmarks 
         for name, setup in benchmarks.items():
+            logger.info(f"Running {name}:")
+
             if setup.get("additional_dir") is None:
                 setup["additional_dir"] = ""
+            if setup.get("build_steps") is None:
+                setup["build_steps"] = ""
 
             # Formulate command for each benchmark
             benchmark_cmd = [
@@ -45,12 +63,15 @@ if __name__ == "__main__":
                 args.sdk_path,
                 setup["application_name"],
                 setup["benchmark"],
-                setup["build_steps"],
                 setup["additional_dir"],
+                setup["build_steps"],
             ]
+            logger.info(f"\tcmd = {benchmark_cmd}")
 
             # Run benchmark in a poplar SDK enabled environment
-            with open(f"./{name}.log", "w") as output_stream:
+            log_file = f"./{name}.log"
+            with open(log_file, "w") as output_stream:
+                logger.info(f"\tlogs at: {log_file}")
                 subprocess.run(
                     benchmark_cmd,
                     stdout=output_stream,
@@ -65,4 +86,5 @@ if __name__ == "__main__":
 
                 # Include all results rows
                 for row in benchmark_reader:
+                    logger.info(f"\tResults = {row} - saved")
                     common_writer.writerow(row)

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -1,6 +1,12 @@
 import argparse
+import csv
 import subprocess
 import yaml
+from pathlib import Path
+
+
+HEADER_METRICS = ["benchmark name", "variant_name", "throughput", "latency", "total_compiling_time"]
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -12,25 +18,39 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    # Run all benchmarks 
     benchmarks = yaml.load(open(args.spec).read(), Loader=yaml.FullLoader)
     
-    for name, setup in benchmarks.items():
-        # Formulate command from each benchmark
-        benchmark_cmd = [
-            "source",
-            "./assess_platform.sh",
-            setup["application_name"],
-            setup["benchmark"],
-            setup["build_steps"]
-        ]
+    # Write all results into a common CSV
+    with open(Path(args.log_dir, "assessment_results.csv"), "w") as common_file:
+        # Use a fixed set of headers
+        common_writer = csv.writer(common_file, quoting=csv.QUOTE_ALL)
+        common_writer.writerow(HEADER_METRICS)
 
-        # Run benchmark in a poplar SDK enabled environment
-        with open(f"./{name}.log", "w") as output_stream:
-            subprocess.run(
-                benchmark_cmd,
-                stdout=output_stream,
-                stderr=output_stream,
-            )
-        
-        # Merge CSV outputs into one
+        # Run all benchmarks 
+        for name, setup in benchmarks.items():
+            # Formulate command for each benchmark
+            benchmark_cmd = [
+                "source",
+                "./assess_platform.sh",
+                setup["application_name"],
+                setup["benchmark"],
+                setup["build_steps"]
+            ]
+
+            # Run benchmark in a poplar SDK enabled environment
+            with open(f"./{name}.log", "w") as output_stream:
+                subprocess.run(
+                    benchmark_cmd,
+                    stdout=output_stream,
+                    stderr=output_stream,
+                )
+            
+            # Merge CSV outputs from this benchmark into the common CSV
+            with open(Path(f"/tmp/{setup['application_name']}_logs/benchmark_results.csv"), "r") as benchmark_csv:
+                # Skip header
+                benchmark_reader = csv.reader(benchmark_csv)
+                _ = next(benchmark_reader)
+
+                # Include all results rows
+                for row in benchmark_reader:
+                    common_writer.writerow(row)

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -2,6 +2,7 @@ import argparse
 import csv
 import subprocess
 import yaml
+from getpass import getpass
 from pathlib import Path
 
 
@@ -16,6 +17,12 @@ if __name__ == "__main__":
         type=str,
         help="Path to yaml file with benchmark spec",
     )
+    parser.add_argument(
+        "--sdk-path",
+        required=True,
+        type=str,
+        help="Path to the SDK root dir used for benchmarking",
+    )
     args = parser.parse_args()
 
     benchmarks = yaml.load(open(args.spec).read(), Loader=yaml.FullLoader)
@@ -28,13 +35,18 @@ if __name__ == "__main__":
 
         # Run all benchmarks 
         for name, setup in benchmarks.items():
+            if setup.get("additional_dir") is None:
+                setup["additional_dir"] = ""
+
             # Formulate command for each benchmark
             benchmark_cmd = [
-                "source",
+                "bash",
                 "./assess_platform.sh",
+                args.sdk_path,
                 setup["application_name"],
                 setup["benchmark"],
-                setup["build_steps"]
+                setup["build_steps"],
+                setup["additional_dir"],
             ]
 
             # Run benchmark in a poplar SDK enabled environment

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.sh
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.sh
@@ -5,6 +5,8 @@ SDK_PATH="~/sdks/"
 APPLICATION_NAME=$1
 BENCHMARK=$2
 BUILD_STEPS=$3
+# Only for Pytorch cnns for now, the one exception
+ADDITIONAL_DIR=$4
 
 # Enable SDK (poplar and popart)
 cd SDK_PATH/poplar-*
@@ -24,10 +26,6 @@ source ~/$APPLICATION/bin/activate
 # Upgrade pip
 pip3 install --upgrade pip
 
-# Install the framework-specific wheels
-cd SDK_PATH
-pip3 install 
-
 # Determine framework used
 FRAMEWORK=${BENCHMARK_NAME:0:3}
 if [[ $FRAMEWORK == "pyt" ]]
@@ -35,7 +33,8 @@ then
     FRAMEWORK="pytorch"
 fi
 
-# Install application requirementsx
+# Install the framework-specific wheels
+cd SDK_PATH
 if [[ $FRAMEWORK == "pytorch" ]]
 then
     pip3 install poptorch*
@@ -51,12 +50,17 @@ then
 fi
 
 pip3 install horovod*
+cd -
+
+# Install application requirementsx
+cd ~/examples/*/$APP_NAME/$FRAMEWORK/$ADDITIONAL_DIR/
+pip3 install -r requirements.txt
 
 # Run additional build steps
 eval " $BUILD_STEPS"
 
 # Run benchmark
-python3 -m examples-utils --spec ~/examples/*/$APP_NAME/$FRAMEWORK/benchmark --benchmark $BENCHMARK --logdir ./${APP_NAME}_logs/
+python3 -m examples-utils --spec ./$ADDITIONAL_DIR/benchmarks.yml --benchmark $BENCHMARK --logdir ./tmp/${APP_NAME}_logs/
 
 # Deactivate venv and disable sdk
 deactivate

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.sh
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.sh
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 #!/bin/bash
 
 # Inputs with defaults

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.sh
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.sh
@@ -1,27 +1,29 @@
 #!/bin/bash
 
 # Default inputs
-SDK_PATH="~/sdks/"
-APPLICATION_NAME=$1
-BENCHMARK=$2
-BUILD_STEPS=$3
+SDK_PATH=$1
+APPLICATION_NAME=$2
+BENCHMARK_NAME=$3
+BUILD_STEPS=$4
 # Only for Pytorch cnns for now, the one exception
-ADDITIONAL_DIR=$4
+ADDITIONAL_DIR=$5
 
 # Enable SDK (poplar and popart)
-cd SDK_PATH/poplar-*
+cd $SDK_PATH/poplar-*
 source enable.sh
-cd -
+cd - > /dev/null
 
-cd SDK_PATH/popart-*
+cd $SDK_PATH/popart-*
 source enable.sh
-cd -
+cd - > /dev/null
+echo "Poplar SDK at ${SDK_PATH} enabled"
 
 # Create and activate venv
 # Assuming a compatible version of python is already available
-apt-get install python3-virtualenv
-python3 -m venv ~/$APPLICATION
-source ~/$APPLICATION/bin/activate
+sudo apt-get install python3-virtualenv
+python3 -m venv ~/$APPLICATION_NAME
+source ~/$APPLICATION_NAME/bin/activate
+echo "Python venv at ${HOME}/${APPLICATION_NAME} activated"
 
 # Upgrade pip
 pip3 install --upgrade pip
@@ -30,11 +32,11 @@ pip3 install --upgrade pip
 FRAMEWORK=${BENCHMARK_NAME:0:3}
 if [[ $FRAMEWORK == "pyt" ]]
 then
-    FRAMEWORK="pytorch"
+    $FRAMEWORK="pytorch"
 fi
 
 # Install the framework-specific wheels
-cd SDK_PATH
+cd $SDK_PATH
 if [[ $FRAMEWORK == "pytorch" ]]
 then
     pip3 install poptorch*
@@ -49,20 +51,20 @@ then
     pip3 install keras-2*
 fi
 
-pip3 install horovod*
-cd -
+# pip3 install horovod*
+# cd -
 
-# Install application requirementsx
-cd ~/examples/*/$APP_NAME/$FRAMEWORK/$ADDITIONAL_DIR/
-pip3 install -r requirements.txt
+# # Install application requirementsx
+# cd ~/examples/*/$APP_NAME/$FRAMEWORK/$ADDITIONAL_DIR/
+# pip3 install -r requirements.txt
 
-# Run additional build steps
-eval " $BUILD_STEPS"
+# # Run additional build steps
+# eval " $BUILD_STEPS"
 
-# Run benchmark
-python3 -m examples-utils --spec ./$ADDITIONAL_DIR/benchmarks.yml --benchmark $BENCHMARK --logdir ./tmp/${APP_NAME}_logs/
+# # Run benchmark
+# python3 -m examples-utils --spec ./$ADDITIONAL_DIR/benchmarks.yml --benchmark $BENCHMARK --logdir ./tmp/${APP_NAME}_logs/
 
-# Deactivate venv and disable sdk
-deactivate
-rm -rf ~/$APPLICATION
-popsdk-clean
+# # Deactivate venv and disable sdk
+# deactivate
+# rm -rf ~/$APPLICATION
+# popsdk-clean

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.sh
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Default inputs
+SDK_PATH="~/sdks/"
+APPLICATION_NAME=$1
+BENCHMARK=$2
+BUILD_STEPS=$3
+
+# Enable SDK (poplar and popart)
+cd SDK_PATH/poplar-*
+source enable.sh
+cd -
+
+cd SDK_PATH/popart-*
+source enable.sh
+cd -
+
+# Create and activate venv
+# Assuming a compatible version of python is already available
+apt-get install python3-virtualenv
+python3 -m venv ~/$APPLICATION
+source ~/$APPLICATION/bin/activate
+
+# Upgrade pip
+pip3 install --upgrade pip
+
+# Install the framework-specific wheels
+cd SDK_PATH
+pip3 install 
+
+# Determine framework used
+FRAMEWORK=${BENCHMARK_NAME:0:3}
+if [[ $FRAMEWORK == "pyt" ]]
+then
+    FRAMEWORK="pytorch"
+fi
+
+# Install application requirementsx
+if [[ $FRAMEWORK == "pytorch" ]]
+then
+    pip3 install poptorch*
+elif [[ $FRAMEWORK == "tf1" ]]
+then
+    pip3 install tensorflow-1*amd*
+    pip3 install ipu_tensorflow_addons-1*
+elif [[ $FRAMEWORK == "tf2" ]]
+then
+    pip3 install tensorflow-2*amd*
+    pip3 install ipu_tensorflow_addons-2*
+    pip3 install keras-2*
+fi
+
+pip3 install horovod*
+
+# Run additional build steps
+eval " $BUILD_STEPS"
+
+# Run benchmark
+python3 -m examples-utils --spec ~/examples/*/$APP_NAME/$FRAMEWORK/benchmark --benchmark $BENCHMARK --logdir ./${APP_NAME}_logs/
+
+# Deactivate venv and disable sdk
+deactivate
+rm -rf ~/$APPLICATION
+popsdk-clean

--- a/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
@@ -4,13 +4,20 @@
 # want to test both the IPUs and the Hosts on a new platform
 
 # IPU intensive benchmarks
-popart_bert:
+tgn:
   application_name: tgn
   benchmark: tf1_tgn_train_real_1ipu
-  build_steps: ""
 
-pytorch_bert:
-  application_name: bert
-  benchmark: pytorch_bert_large_packed_pretrain_real_pod16
-  build_steps: "make clean && make"
+tgn_conv:
+  application_name: tgn
+  benchmark: tf1_tgn_train_real_1ipu_conv
 
+# pytorch_bert:
+#   application_name: bert
+#   benchmark: pytorch_bert_large_packed_pretrain_real_pod16
+#   build_steps: "make clean && make"
+
+# tf_resnet:
+#   application_name: cnns
+#   benchmark: tensorflow1_resnet50_train_real_pod16_conv
+#   additional_dir: "training"

--- a/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
@@ -3,21 +3,19 @@
 # for the platform assessment tools, and also as a suggestion, for users who
 # want to test both the IPUs and the Hosts on a new platform
 
-# IPU intensive benchmarks
+# Quick test
 tgn:
   application_name: tgn
   benchmark: tf1_tgn_train_real_1ipu
 
-tgn_conv:
-  application_name: tgn
-  benchmark: tf1_tgn_train_real_1ipu_conv
+# IPU intensive benchmark
+pytorch_bert:
+  application_name: bert
+  benchmark: pytorch_bert_large_packed_pretrain_real_pod16
+  build_steps: "make clean && make"
 
-# pytorch_bert:
-#   application_name: bert
-#   benchmark: pytorch_bert_large_packed_pretrain_real_pod16
-#   build_steps: "make clean && make"
-
-# tf_resnet:
-#   application_name: cnns
-#   benchmark: tensorflow1_resnet50_train_real_pod16_conv
-#   additional_dir: "training"
+# Host intensive benchmark
+tf_resnet:
+  application_name: cnns
+  benchmark: tensorflow1_resnet50_train_real_pod16_conv
+  additional_dir: "training"

--- a/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
@@ -1,0 +1,26 @@
+---
+# This file acts both as a template, demonstrating how to create a yaml file
+# for the platform assessment tools, and also as a suggestion, for users who
+# want to test both the IPUs and the Hosts on a new platform
+
+# IPU intensive benchmarks
+popart_bert:
+  application_name: bert
+  benchmark: popart_bert_large_pretrain_real_pod16
+  build_steps: "make clean && make"
+
+pytorch_bert:
+  application_name: bert
+  benchmark: pytorch_bert_large_pretrain_real_pod16
+  build_steps: "make clean && make"
+
+# Host intensive benchmarks
+tensorflow1_resnet:
+  application_name: cnns
+  benchmark: popart_bert_large_pretrain_real_pod16
+  build_steps: ""
+
+pytorch_resnet:
+  application_name: cnns
+  benchmark: pytorch_bert_large_pretrain_real_pod16
+  build_steps: "make clean && make all"

--- a/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform_benchmarks.yml
@@ -5,22 +5,12 @@
 
 # IPU intensive benchmarks
 popart_bert:
-  application_name: bert
-  benchmark: popart_bert_large_pretrain_real_pod16
-  build_steps: "make clean && make"
+  application_name: tgn
+  benchmark: tf1_tgn_train_real_1ipu
+  build_steps: ""
 
 pytorch_bert:
   application_name: bert
-  benchmark: pytorch_bert_large_pretrain_real_pod16
+  benchmark: pytorch_bert_large_packed_pretrain_real_pod16
   build_steps: "make clean && make"
 
-# Host intensive benchmarks
-tensorflow1_resnet:
-  application_name: cnns
-  benchmark: popart_bert_large_pretrain_real_pod16
-  build_steps: ""
-
-pytorch_resnet:
-  application_name: cnns
-  benchmark: pytorch_bert_large_pretrain_real_pod16
-  build_steps: "make clean && make all"

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -441,7 +441,7 @@ def run_benchmarks(args: argparse.ArgumentParser):
     with open(Path(args.log_dir, "benchmark_results.csv"), "w") as csv_file:
         writer = csv.writer(csv_file, quoting=csv.QUOTE_ALL)
         # Use a fixed set of headers, any more detail belongs in the JSON file
-        writer.writerow(["Benchmark name", "Variant name"] + csv_metrics)
+        writer.writerow(["benchmark name", "Variant name"] + csv_metrics)
 
         # Write a row for each variant
         for benchmark, result in results.items():


### PR DESCRIPTION
Adding platform assessment tools to examples utils benchmarking.

NOTE: This code will not be exposed to the user through the examples utils API, it is placed here for internal or supervised use, and hence makes certain assumptions/decisions that would not be suitable for code exposed to the general user. 

This change adds lightweight scripts to automate the assessment of a platform using a fixed set of applications. Requires minimal user input and can be automated across cloud instances/machines. 

Locally tested for general use/edge cases, but live stress testing pending, as it needs to be available on github first realistically. 