### PR TITLE
Adding documentation for platform assessment tools

### DIFF
--- a/examples_utils/benchmarks/README.md
+++ b/examples_utils/benchmarks/README.md
@@ -27,6 +27,8 @@ python3 -m examples_utils benchmark --spec /path/to/application/benchmarks.yml -
 python3 -m examples_utils benchmark --spec /path/to/application/benchmarks.yml /path/to/another/application/benchmarks.yml
 ```
 
+NOTE: if running using code from a custom examples directory (moved or renamed etc.) then please pass the `--examples-location` argument and provide the path to the directory containing the custom examples directory.
+
 ## Other functionality
 In addition to the logs and metrics already recorded, there are a few other features included for making benchmarking easier and more customisable. Please see the output of 'python3 -m examples_utils benchmark -help' for more info
 

--- a/examples_utils/benchmarks/changelog.md
+++ b/examples_utils/benchmarks/changelog.md
@@ -10,4 +10,6 @@
 - 30/07 - Multi-host + Multi-instance benchmarks can now be run with this
 - 02/08 - Benchmark ordering, wandb default behaviour and other minor fixes
 - 04/08 - More robust pathfinding capabilities to avoid excessive user input
-- 09/08 - Adding a poprun early warning system to demistify poprun errors, and other small QoL fixes 
+- 15/08 - Adding platform assessment tools as a set of scripts only
+- 17/08 - Adding a poprun early warning system to demistify poprun errors, and other small QoL fixes
+- 18/08 - Adding documentation for platform assessment tools

--- a/examples_utils/benchmarks/platform_assessment/README.md
+++ b/examples_utils/benchmarks/platform_assessment/README.md
@@ -1,0 +1,38 @@
+# Applications benchmarking
+## Platform assessment tool (benchmark automation)
+
+## Summary
+A tool for automating and simplifying the process of assessing a new platform (running multiple benchmarks auotmatically in individual environments)
+
+## Platform assessment
+One of the assessments of a new platform/service is to run a selection of applications and compare the performance of those to reference values we have from our own machines tested at SDK releases or in nightly performance tests. This set of scripts wraps the examples_utils benchmark sub-module with a set of environment setup commands, inferring the required environment from the benchmark name itself.
+
+Individual benchmarks are run (in order) according to `assess_platform_benchmarks.yml` (or any alternate compatible yaml file provided with the `--spec` argument), and the results of these are merged into `benchmark_results.csv`, created in this directory. For details on how benchmarks are run, please refer to the documentation provided with
+
+## Automated environment setup 
+In summary, these are the steps that the `assess_platform.sh` wrapper script carries out:
+- Enable the SDK provided in `--sdk-path`
+- Create a python virtual environment and update pip
+- Determine the framework needed for the benchmark
+- Install the framework specific wheels, and horovod
+- Navigate to the application root dir (assuming `examples` is in the home directory in `$HOME`)
+- Install application requirements
+- Run the benchmark using examples_utils benchmark
+- Deactivate and remove the python virtual environment and disable the SDK
+
+## Installation/Setup
+There are no steps to build or install this set of scripts, all packages used are python standard library and the enviroment setup will install the application requirements and examples_utils benchmark as well.
+
+## Usage
+To run with the provided benchmarks in `assess_platform_benchmarks.yml`, simply run:
+```
+python3 assess_platform.py --sdk-path <path to a specific sdk root dir>
+```
+
+If you want to provide your own yaml file, then simply pass the path to it with `--spec`.
+
+## Changelog
+Please see the changelog in examples_utils/benchmarks for details in changes to this tool.
+
+## Future work plans
+Please see the `Future work plans` section in examples_utils/benchmarks for details of future work plans for this tool.

--- a/examples_utils/benchmarks/platform_assessment/assess_platform.py
+++ b/examples_utils/benchmarks/platform_assessment/assess_platform.py
@@ -20,16 +20,16 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--spec",
-        required=True,
-        type=str,
-        help="Path to yaml file with benchmark spec",
-    )
-    parser.add_argument(
         "--sdk-path",
         required=True,
         type=str,
         help="Path to the SDK root dir used for benchmarking",
+    )
+    parser.add_argument(
+        "--spec",
+        default=Path(Path(__file__).resolve().parent, "./assess_platform_benchmarks.yml"),
+        type=str,
+        help="Path to yaml file with benchmark spec",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Adds documentation for the platform assessment tools as they will soon be used by external users for running applications on new platforms/services. 

In addition:
- Defaults the `--spec` argument to the yaml file provided in the directory
- Adds a note in the examples_utils benchmark 