### PR TITLE
Support benchmarking of jupyter notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,27 @@ The package includes some command line interface utils. For more details refer t
 python -m examples_utils --help
 ```
 
+## Installation
+
+This package can be installed from source via pip:
+
+```console
+python -m pip install https://github.com/graphcore/examples-utils.git
+```
+
+By default it will only install a minimal set of requirements. To benchmark notebooks you must
+install the "jupyter" set of requirements:
+
+```console
+python -m pip install https://github.com/graphcore/examples-utils.git[jupyter]
+```
+
 ## Benchmarking
 
 The benchmarking sub-package is used for running the benchmarks that are provided with example applications in the [examples](https://github.com/graphcore/examples) repository. For more information, refer to the [benchmark's README](https://github.com/graphcore/examples-utils/blob/master/examples_utils/benchmarks/README.md).
 
 ## Development
+
 * Reformat code to repo standard: `make lint`
 * Use [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html)
 * Do not push to master branch. Make changes through github PR requests.

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -153,9 +153,10 @@ def formulate_benchmark_command(
     else:
         py_name = "python"
     called_file = cmd_parts[cmd_parts.index(py_name) + 1]
-
-    resolved_file = str(Path(called_file).resolve())
-    cmd = cmd.replace(called_file, resolved_file)
+    # if the first argument is `-m` we are calling a module and shouldn't resolve it
+    if called_file != "-m":
+        resolved_file = str(Path(called_file).resolve())
+        cmd = cmd.replace(called_file, resolved_file)
 
     if not args.allow_wandb and "--wandb" in cmd:
         logger.info("'--allow-wandb' was not passed, however '--wandb' is an "
@@ -197,7 +198,7 @@ def get_poprun_hosts(cmd: list) -> list:
 
     Returns:
         poprun_hostnames (list): names/IPs of poprun hosts
-    
+
     """
 
     # Find where in the command list "poprun", "host" and "python" exist

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,10 +1,48 @@
+import os
+
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
+from nbconvert import Exporter
+from nbformat import NotebookNode
+from nbconvert.exporters.exporter import ResourcesDict
 
 
-def run_notebook(notebook_filename, cwd):
-    """helper to run notebooks which may or may not be expected to fail"""
+def run_notebook(notebook_filename: str, working_directory: str) -> str:
+    """Run a notebook and return all its outputs to stdstream together
+
+    Args:
+        notebook_filename: The path to the notebook file that needs testing
+        working_directory: The working directory from which the notebook is
+            to be run.
+    """
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
     ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
-    ep.preprocess(nb, {"metadata": {"path": f"{cwd}"}})
+    ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
+
+    exporter = OutputExporter()
+    output = exporter.from_notebook_node(nb)
+    return output
+
+
+class OutputExporter(Exporter):
+    """nbconvert Exporter to export notebook output as single string source code."""
+
+    # Extension of the file that should be written to disk (used by parent class)
+    file_extension = ".py"
+
+    def from_notebook_node(self, nb: NotebookNode, **kwargs):
+        notebook, _ = super().from_notebook_node(nb, **kwargs)
+
+        cell_outputs = [
+            output.get("text", "") + os.linesep
+            for cell in notebook.cells
+            if cell.cell_type == "code"
+            for output in cell.outputs
+            if output
+            if output.get("output_type") == "stream"
+        ]
+
+        outputs = os.linesep.join(cell_outputs)
+
+        return outputs, ResourcesDict()

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,0 +1,10 @@
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+
+def run_notebook(notebook_filename, cwd):
+    """helper to run notebooks which may or may not be expected to fail"""
+    with open(notebook_filename) as f:
+        nb = nbformat.read(f, as_version=4)
+    ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
+    ep.preprocess(nb, {"metadata": {"path": f"{cwd}"}})

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -4,7 +4,7 @@ import argparse
 
 try:
     import nbformat
-    from nbconvert.preprocessors import ExecutePreprocessor
+    from nbconvert.preprocessors import ExecutePreprocessor, CellExecutionError
     from nbconvert import Exporter
     from nbformat import NotebookNode
     from nbconvert.exporters.exporter import ResourcesDict
@@ -28,9 +28,13 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
     ep = ExecutePreprocessor(timeout=timeout, kernel_name="python3")
-    ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-
     exporter = OutputExporter()
+    try:
+        ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
+    except CellExecutionError:
+        output, _ = exporter.from_notebook_node(nb)
+        print(output)
+        raise
     output, _ = exporter.from_notebook_node(nb)
     return output
 

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -33,7 +33,14 @@ class OutputExporter(Exporter):
 
     def from_notebook_node(self, nb: NotebookNode, **kwargs):
         notebook, _ = super().from_notebook_node(nb, **kwargs)
-
+        # notebooks are lists of cells, code cells are of the format:
+        # {"cell_type": "code",
+        #  "outputs":[
+        #     {
+        #         "output_type": "stream"|"bytes",
+        #         "text":"text of interest that we want to capture"
+        #     }, ...]}
+        # Hence the following list comprehension:
         cell_outputs = [
             output.get("text", "") + os.linesep
             for cell in notebook.cells

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,11 +1,18 @@
 import os
 import argparse
 
-import nbformat
-from nbconvert.preprocessors import ExecutePreprocessor
-from nbconvert import Exporter
-from nbformat import NotebookNode
-from nbconvert.exporters.exporter import ResourcesDict
+try:
+    import nbformat
+    from nbconvert.preprocessors import ExecutePreprocessor
+    from nbconvert import Exporter
+    from nbformat import NotebookNode
+    from nbconvert.exporters.exporter import ResourcesDict
+except (ImportError, ModuleNotFoundError) as error:
+    raise ModuleNotFoundError(
+        "To use notebook utilities `examples_utils` needs to have been installed with "
+        "the [jupyter] set of requirements, reinstall the package with"
+        " `pip install examples_utils[jupyter]`"
+    ) from error
 
 DEFAULT_TIMEOUT = 600
 
@@ -26,7 +33,7 @@ def run_notebook(
     ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
 
     exporter = OutputExporter()
-    output = exporter.from_notebook_node(nb)
+    output, _ = exporter.from_notebook_node(nb)
     return output
 
 
@@ -66,7 +73,7 @@ def cli():
     parser.add_argument("working_dir", type=str, help="The working directory in which to run")
     parser.add_argument("--timeout", type=int,default=DEFAULT_TIMEOUT, help="The timeout of the notebook")
     arg = parser.parse_args()
-    stream, _ = run_notebook(arg.filename, arg.working_dir, arg.timeout)
+    stream = run_notebook(arg.filename, arg.working_dir, arg.timeout)
     print(stream)
 
 if __name__ == "__main__":

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import os
 import argparse
 
@@ -8,18 +9,14 @@ try:
     from nbformat import NotebookNode
     from nbconvert.exporters.exporter import ResourcesDict
 except (ImportError, ModuleNotFoundError) as error:
-    raise ModuleNotFoundError(
-        "To use notebook utilities `examples_utils` needs to have been installed with "
-        "the [jupyter] set of requirements, reinstall the package with"
-        " `pip install examples_utils[jupyter]`"
-    ) from error
+    raise ModuleNotFoundError("To use notebook utilities `examples_utils` needs to have been installed with "
+                              "the [jupyter] set of requirements, reinstall the package with"
+                              " `pip install examples_utils[jupyter]`") from error
 
 DEFAULT_TIMEOUT = 600
 
 
-def run_notebook(
-    notebook_filename: str, working_directory: str, timeout: int=DEFAULT_TIMEOUT
-) -> str:
+def run_notebook(notebook_filename: str, working_directory: str, timeout: int = DEFAULT_TIMEOUT) -> str:
     """Run a notebook and return all its outputs to stdstream together
 
     Args:
@@ -54,12 +51,8 @@ class OutputExporter(Exporter):
         #     }, ...]}
         # Hence the following list comprehension:
         cell_outputs = [
-            output.get("text", "") + os.linesep
-            for cell in notebook.cells
-            if cell.cell_type == "code"
-            for output in cell.outputs
-            if output
-            if output.get("output_type") == "stream"
+            output.get("text", "") + os.linesep for cell in notebook.cells if cell.cell_type == "code"
+            for output in cell.outputs if output if output.get("output_type") == "stream"
         ]
 
         outputs = os.linesep.join(cell_outputs)
@@ -71,10 +64,11 @@ def cli():
     parser = argparse.ArgumentParser()
     parser.add_argument("filename", type=str, help="The filename of the notebook to run")
     parser.add_argument("working_dir", type=str, help="The working directory in which to run")
-    parser.add_argument("--timeout", type=int,default=DEFAULT_TIMEOUT, help="The timeout of the notebook")
+    parser.add_argument("--timeout", type=int, default=DEFAULT_TIMEOUT, help="The timeout of the notebook")
     arg = parser.parse_args()
     stream = run_notebook(arg.filename, arg.working_dir, arg.timeout)
     print(stream)
+
 
 if __name__ == "__main__":
     cli()

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -24,6 +24,7 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
         working_directory: The working directory from which the notebook is
             to be run.
     """
+
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
     ep = ExecutePreprocessor(timeout=timeout, kernel_name="python3")

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,4 +1,5 @@
 import os
+import argparse
 
 import nbformat
 from nbconvert.preprocessors import ExecutePreprocessor
@@ -6,8 +7,12 @@ from nbconvert import Exporter
 from nbformat import NotebookNode
 from nbconvert.exporters.exporter import ResourcesDict
 
+DEFAULT_TIMEOUT = 600
 
-def run_notebook(notebook_filename: str, working_directory: str) -> str:
+
+def run_notebook(
+    notebook_filename: str, working_directory: str, timeout: int=DEFAULT_TIMEOUT
+) -> str:
     """Run a notebook and return all its outputs to stdstream together
 
     Args:
@@ -17,7 +22,7 @@ def run_notebook(notebook_filename: str, working_directory: str) -> str:
     """
     with open(notebook_filename) as f:
         nb = nbformat.read(f, as_version=4)
-    ep = ExecutePreprocessor(timeout=600, kernel_name="python3")
+    ep = ExecutePreprocessor(timeout=timeout, kernel_name="python3")
     ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
 
     exporter = OutputExporter()
@@ -53,3 +58,16 @@ class OutputExporter(Exporter):
         outputs = os.linesep.join(cell_outputs)
 
         return outputs, ResourcesDict()
+
+
+def cli():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filename", type=str, help="The filename of the notebook to run")
+    parser.add_argument("working_dir", type=str, help="The working directory in which to run")
+    parser.add_argument("--timeout", type=int,default=DEFAULT_TIMEOUT, help="The timeout of the notebook")
+    arg = parser.parse_args()
+    stream, _ = run_notebook(arg.filename, arg.working_dir, arg.timeout)
+    print(stream)
+
+if __name__ == "__main__":
+    cli()

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -56,6 +56,7 @@ def run_and_monitor_progress(cmd: list, listener: TextIOWrapper, timeout: int = 
         cmd (list): The command to be run, as a list for use by subprocess
         listener (TextIOWrapper): Listener that takes the output from the process
         timeout (int): Seconds until the process will timeout, forcing termination
+        kwargs: all additional keyword arguments are passed to `subprocess.Popen`.
 
     Returns:
         output (str): stdout from the process

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -237,7 +237,7 @@ def run_benchmark_variant(
         logger.info(f"Install python requirements")
         if not Path(reqs).exists():
             raise FileNotFoundError(f"Invalid python requirements where specified at {reqs}")
-        subprocess.check_output(["python", "-m", "pip", "install", "-r", str(reqs)])
+        subprocess.check_output([sys.executable, "-m", "pip", "install", "-r", str(reqs)])
 
     logger.info(f"Start test: {start_time}")
     stdout, stderr, exitcode = run_and_monitor_progress(
@@ -348,6 +348,11 @@ def process_notebook_to_command(variant, name="unknown"):
     notebook_def = variant.pop("notebook")
     if not isinstance(notebook_def, dict):
         notebook_def = {"file": str(notebook_def)}
+
+    allowed_fields = {"file", "working_directory", "timeout"}
+    unknown_entries = [f for f in notebook_def if f not in allowed_fields]
+    if unknown_entries:
+        raise yaml.YAMLError(f"Notebook entry '{name}' has un-recognised options: {unknown_entries}")
     variant["cmd"] = " ".join([
         f"python3",
         "-m",

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -333,18 +333,17 @@ def run_benchmark_variant(
     return variant_result
 
 
-def process_notebook_to_command(variant):
+def process_notebook_to_command(variant, name="unknown"):
     if "notebook" not in variant:
         return variant
     if "notebook" in variant and "cmd" in variant:
         raise ValueError(
             "Invalid combination of entries 'notebook' and 'cmd' in "
-            f"benchmark: {variant.get('name', 'unknown')}"
+            f"benchmark: {name}"
         )
     notebook_def = variant.pop("notebook")
     if not isinstance(notebook_def, dict):
         notebook_def = {"file": str(notebook_def)}
-
     variant["cmd"] = " ".join([
         f"python3", "-m","examples_utils.benchmarks.notebook_utils",
         str(notebook_def['file']),

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -137,12 +137,12 @@ def run_and_monitor_progress(cmd: list, listener: TextIOWrapper, timeout: int = 
 
 
 def run_benchmark_variant(
-        variant_name: str,
-        benchmark_name: str,
-        variant_dict: dict,
-        benchmark_dict: dict,
-        listener: TextIOWrapper,
-        args: argparse.ArgumentParser,
+    variant_name: str,
+    benchmark_name: str,
+    variant_dict: dict,
+    benchmark_dict: dict,
+    listener: TextIOWrapper,
+    args: argparse.ArgumentParser,
 ) -> dict:
     """Run a variant and collect results.
 
@@ -344,7 +344,8 @@ def process_notebook_to_command(variant, name="unknown"):
     if "notebook" not in variant:
         return variant
     if "notebook" in variant and "cmd" in variant:
-        raise ValueError("Invalid combination of entries 'notebook' and 'cmd' in " f"benchmark: {name}")
+        raise ValueError("Invalid combination of entries 'notebook' and 'cmd' in "
+                         f"benchmark: {name}")
     notebook_def = variant.pop("notebook")
     if not isinstance(notebook_def, dict):
         notebook_def = {"file": str(notebook_def)}

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -232,6 +232,13 @@ def run_benchmark_variant(
         setup_distributed_filesystems(args, poprun_hostnames)
 
     start_time = datetime.now()
+    reqs = benchmark_dict.get("requirements_file")
+    if reqs:
+        logger.info(f"Install python requirements")
+        if not Path(reqs).exists():
+            raise FileNotFoundError(f"Invalid python requirements where specified at {reqs}")
+        subprocess.check_output(["python", "-m", "pip", "install", "-r", str(reqs)])
+
     logger.info(f"Start test: {start_time}")
     stdout, stderr, exitcode = run_and_monitor_progress(
         cmd,

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -45,7 +45,6 @@ from examples_utils.benchmarks.metrics_utils import (
 )
 from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 
-
 # Get the module logger
 logger = logging.getLogger()
 
@@ -337,19 +336,17 @@ def process_notebook_to_command(variant, name="unknown"):
     if "notebook" not in variant:
         return variant
     if "notebook" in variant and "cmd" in variant:
-        raise ValueError(
-            "Invalid combination of entries 'notebook' and 'cmd' in "
-            f"benchmark: {name}"
-        )
+        raise ValueError("Invalid combination of entries 'notebook' and 'cmd' in " f"benchmark: {name}")
     notebook_def = variant.pop("notebook")
     if not isinstance(notebook_def, dict):
         notebook_def = {"file": str(notebook_def)}
     variant["cmd"] = " ".join([
-        f"python3", "-m","examples_utils.benchmarks.notebook_utils",
+        f"python3",
+        "-m",
+        "examples_utils.benchmarks.notebook_utils",
         str(notebook_def['file']),
         str(notebook_def.get('working_directory', '.')),
-    ] + (["--timeout", str(notebook_def['timeout'])] if "timeout" in notebook_def else [])
-    )
+    ] + (["--timeout", str(notebook_def['timeout'])] if "timeout" in notebook_def else []))
 
     return variant
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -137,12 +137,12 @@ def run_and_monitor_progress(cmd: list, listener: TextIOWrapper, timeout: int = 
 
 
 def run_benchmark_variant(
-    variant_name: str,
-    benchmark_name: str,
-    variant_dict: dict,
-    benchmark_dict: dict,
-    listener: TextIOWrapper,
-    args: argparse.ArgumentParser,
+        variant_name: str,
+        benchmark_name: str,
+        variant_dict: dict,
+        benchmark_dict: dict,
+        listener: TextIOWrapper,
+        args: argparse.ArgumentParser,
 ) -> dict:
     """Run a variant and collect results.
 
@@ -344,8 +344,7 @@ def process_notebook_to_command(variant, name="unknown"):
     if "notebook" not in variant:
         return variant
     if "notebook" in variant and "cmd" in variant:
-        raise ValueError("Invalid combination of entries 'notebook' and 'cmd' in "
-                         f"benchmark: {name}")
+        raise ValueError("Invalid combination of entries 'notebook' and 'cmd' in " f"benchmark: {name}")
     notebook_def = variant.pop("notebook")
     if not isinstance(notebook_def, dict):
         notebook_def = {"file": str(notebook_def)}

--- a/examples_utils/testing/test_commands.py
+++ b/examples_utils/testing/test_commands.py
@@ -1,0 +1,82 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+from typing import Union, List
+import subprocess
+import warnings
+
+DEFAULT_PROCESS_TIMEOUT_SECONDS = 40 * 60
+
+
+class CalledProcessError(subprocess.CalledProcessError):
+    """An error for subprocesses which captures stdout and stderr in the error message."""
+
+    def __str__(self) -> str:
+        original_message = super().__str__()
+        return f"{original_message}\n" f"{self.stdout}\n" f"{self.stderr}"
+
+
+def run_command_fail_explicitly(
+        command: Union[str, List[str]],
+        cwd: str = ".",
+        *,
+        suppress_warnings: bool = False,
+        **kwargs,
+) -> str:
+    """Runs a command returning the output or failing with useful information
+
+    Args:
+        command: The command to execute, can also be a space separated string.
+        cwd: The directory in which the command should be
+            launched. If called by a pytest test function or method, this
+            probably should be a `tmp_path` fixture.
+        suppress_warnings: Do not include warnings in stdout, so it can be
+                           parsed more reliably. Will still be captured if
+                           command raises an exception.
+        **kwargs: Additional keyword arguments are passed to
+            `subprocess.check_output`.
+
+    Returns:
+        The standard output and error of the command if successfully executed.
+
+    Raises:
+        RuntimeError: If the subprocess command executes with a non-zero output.
+    """
+
+    if suppress_warnings:
+        # Warn if parameters contradict
+        if "stderr" in kwargs and kwargs["stderr"] != subprocess.PIPE:
+            warnings.warn(
+                "`run_command_fail_explicitly` parameter `suppress_warnings` will"
+                " override other specified parameter `stderr`. Using"
+                " `stderr=subprocess.PIPE`",
+                stacklevel=2,
+            )
+
+        # PIPE rather None, so we can still access from exceptions below
+        kwargs["stderr"] = subprocess.PIPE
+
+    DEFAULT_KWARGS = {
+        "shell": isinstance(command, str) and " " in command,
+        "stderr": subprocess.STDOUT,
+        "timeout": DEFAULT_PROCESS_TIMEOUT_SECONDS,
+        "universal_newlines": True,
+    }
+
+    try:
+        merged_kwargs = {**DEFAULT_KWARGS, **kwargs}
+        out = subprocess.check_output(
+            command,
+            cwd=cwd,
+            **merged_kwargs,
+        )
+    except subprocess.CalledProcessError as e:
+        stdout = e.stdout
+        stderr = e.stderr
+        # type of the stdout stream will depend on the subprocess.
+        # The python docs say decoding is to be handled at
+        # application level.
+        if hasattr(stdout, "decode"):
+            stdout = stdout.decode("utf-8", errors="ignore")
+        if hasattr(stderr, "decode"):
+            stderr = stderr.decode("utf-8", errors="ignore")
+        raise CalledProcessError(1, cmd=command, output=stdout, stderr=stderr) from e
+    return out

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -1,0 +1,2 @@
+nbconvert
+nbformat

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -1,2 +1,3 @@
+ipykernel
 nbconvert
 nbformat

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -1,3 +1,3 @@
-ipykernel
-nbconvert
-nbformat
+ipykernel>=5.5.6
+nbconvert>=6.0.7
+nbformat>=5.1.3

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,12 @@ def read_requirements(path):
     return [line.strip() for line in read(path).split("\n") if not line.startswith(('"', "#", "-"))]
 
 
+extra_requires = {
+    "dev": read_requirements("requirements-dev.txt"),
+    "jupyter": read_requirements("requirements-jupyter.txt"),
+}
+extra_requires["all"] = extra_requires["dev"] + extra_requires["jupyter"]
+
 setup(
     name='examples-utils',
     description="Utils and common code for Graphcore's example applications",
@@ -51,10 +57,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=read_requirements("requirements.txt"),
-    extras_require={
-        "dev": read_requirements("requirements-dev.txt"),
-        "jupyter": read_requirements("requirements-jupyter.txt"),
-    },
+    extras_require=extra_requires,
     packages=['examples_utils'],
     package_data={
         'examples_utils':

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,10 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     install_requires=read_requirements("requirements.txt"),
-    extras_require={"dev": read_requirements("requirements-dev.txt")},
+    extras_require={
+        "dev": read_requirements("requirements-dev.txt"),
+        "jupyter": read_requirements("requirements-jupyter.txt"),
+    },
     packages=['examples_utils'],
     package_data={
         'examples_utils':

--- a/tests/test_files/sample.ipynb
+++ b/tests/test_files/sample.ipynb
@@ -1,0 +1,57 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import examples_utils"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(examples_utils)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notebook has a markdown cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Notebook was run\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.8.9 64-bit",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.8.9"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_files/sample.ipynb
+++ b/tests/test_files/sample.ipynb
@@ -15,7 +15,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(examples_utils)"
+    "print(\"Examples utils test\")"
    ]
   },
   {
@@ -43,7 +43,7 @@
   },
   "language_info": {
    "name": "python",
-   "version": "3.8.9"
+   "version": "3.8.10"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -1,14 +1,26 @@
 from pathlib import Path
-from examples_utils.benchmarks import notebook_utils
+import sys
+import subprocess
 
+from examples_utils.benchmarks import notebook_utils
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 
+
 def test_notebook_runner_captures_outputs():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
-    stdstreams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
-    assert "Notebook was run" in stdstreams
-    assert isinstance(stdstreams, str)
+    std_streams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+    assert "Notebook was run" in std_streams
+    assert isinstance(std_streams, str)
+
+
+def test_cli_equivalence():
+    notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
+    cli_out = subprocess.check_output([sys.executable, "-m", "examples_utils.benchmarks.notebook_utils", str(notebook_path), str(notebook_path.parent)])
+    std_streams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+
+    # There are slightly different newlines from the cli and the function
+    assert std_streams.strip() == cli_out.decode().strip()
 
 
 if __name__ == "__main__":

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -36,6 +36,7 @@ def test_cli_equivalence():
 class TestNotebook2Cmd:
     """Test that conversion from notebook to variant is as expected"""
 
+
     def test_no_op_if_not_there(self):
         variant = {"cmd": "poprun"}
         variant_out = process_notebook_to_command(copy.deepcopy(variant))
@@ -43,6 +44,21 @@ class TestNotebook2Cmd:
             assert variant_out[k] == v
         for k, v in variant_out.items():
             assert variant[k] == v
+
+    def test_unknown_keys_throw_errors(self):
+        notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
+        unknown_key = "not-a-key-name"
+        variant = {
+            "notebook": {
+                "file": notebook_path,
+                "working_directory": notebook_path.parent,
+                unknown_key: None,
+            },
+        }
+        # Check that an error containing the unknown key and the name of the
+        # config is thrown
+        with pytest.raises(Exception, match=f"bad-entry.*{unknown_key}"):
+            process_notebook_to_command(variant, "bad-entry")
 
     def test_error_if_cmd_and_notebook(self):
         variant = {"cmd": "poprun", "notebook": None}

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -51,7 +51,7 @@ class TestNotebook2Cmd:
     def test_replaces_notebook(self, variant_factory):
         notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
         variant = variant_factory(notebook_path)
-        reference_out = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+        reference_out = notebook_utils.run_notebook(notebook_path, variant.get("working_directory", "."))
         variant = process_notebook_to_command(copy.deepcopy(variant))
         cli_out = subprocess.check_output(variant["cmd"].split(" "))
         assert reference_out.strip() == cli_out.decode().strip()

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -1,15 +1,19 @@
 from pathlib import Path
 import sys
 import subprocess
+import copy
+
+import pytest
 
 from examples_utils.benchmarks import notebook_utils
+from examples_utils.benchmarks.run_benchmarks import process_notebook_to_command
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
 
 
 def test_notebook_runner_captures_outputs():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
-    std_streams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+    std_streams = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
     assert "Notebook was run" in std_streams
     assert isinstance(std_streams, str)
 
@@ -17,11 +21,40 @@ def test_notebook_runner_captures_outputs():
 def test_cli_equivalence():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
     cli_out = subprocess.check_output([sys.executable, "-m", "examples_utils.benchmarks.notebook_utils", str(notebook_path), str(notebook_path.parent)])
-    std_streams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+    std_streams = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
 
     # There are slightly different newlines from the cli and the function
     assert std_streams.strip() == cli_out.decode().strip()
 
+
+class TestNotebook2Cmd:
+    """Test that conversion from notebook to variant is as expected"""
+    def test_no_op_if_not_there(self):
+        variant = {"cmd": "poprun"}
+        variant_out = process_notebook_to_command(copy.deepcopy(variant))
+        for k, v in variant.items():
+            assert variant_out[k] == v
+        for k, v in variant_out.items():
+            assert variant[k] == v
+
+    def test_error_if_cmd_and_notebook(self):
+        variant = {"cmd": "poprun", "notebook": None}
+        with pytest.raises(ValueError, match="Invalid combination of entries"):
+            process_notebook_to_command(variant)
+
+
+    @pytest.mark.parametrize("variant_factory", [
+        lambda file: {"notebook": {"file": file},},
+        lambda file: {"notebook": {"file": file, "working_directory": file.parent},},
+        lambda file: {"notebook": file,},
+    ])
+    def test_replaces_notebook(self, variant_factory):
+        notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
+        variant = variant_factory(notebook_path)
+        reference_out = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+        variant = process_notebook_to_command(copy.deepcopy(variant))
+        cli_out = subprocess.check_output(variant["cmd"].split(" "))
+        assert reference_out.strip() == cli_out.decode().strip()
 
 if __name__ == "__main__":
     test_notebook_runner_captures_outputs()

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -35,8 +35,6 @@ def test_cli_equivalence():
 
 class TestNotebook2Cmd:
     """Test that conversion from notebook to variant is as expected"""
-
-
     def test_no_op_if_not_there(self):
         variant = {"cmd": "poprun"}
         variant_out = process_notebook_to_command(copy.deepcopy(variant))

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -9,7 +9,7 @@ from examples_utils.benchmarks import notebook_utils
 from examples_utils.benchmarks.run_benchmarks import process_notebook_to_command
 
 TEST_DIRECTORY = Path(__file__).resolve().parent
-
+SAMPLE_NOTEBOOK = TEST_DIRECTORY / "test_files/sample.ipynb"
 
 def test_notebook_runner_captures_outputs():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
@@ -55,6 +55,21 @@ class TestNotebook2Cmd:
         variant = process_notebook_to_command(copy.deepcopy(variant))
         cli_out = subprocess.check_output(variant["cmd"].split(" "))
         assert reference_out.strip() == cli_out.decode().strip()
+
+
+def test_end_2_end(tmp_path: Path):
+    yaml_file = tmp_path / "sample.yaml"
+    yaml_file.write_text(f"""
+notebook_benchmark:
+    generated: true
+    notebook:
+        file: {SAMPLE_NOTEBOOK}
+    """)
+    out = subprocess.check_output([
+        "python3", "-m", "examples_utils", "benchmark", "--spec", str(yaml_file)
+    ])
+    assert "PASSED notebook_benchmark::notebook_benchmark" in out.decode()
+
 
 if __name__ == "__main__":
     test_notebook_runner_captures_outputs()

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 from pathlib import Path
 import sys
 import subprocess
@@ -11,6 +12,7 @@ from examples_utils.benchmarks.run_benchmarks import process_notebook_to_command
 TEST_DIRECTORY = Path(__file__).resolve().parent
 SAMPLE_NOTEBOOK = TEST_DIRECTORY / "test_files/sample.ipynb"
 
+
 def test_notebook_runner_captures_outputs():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
     std_streams = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
@@ -20,7 +22,11 @@ def test_notebook_runner_captures_outputs():
 
 def test_cli_equivalence():
     notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
-    cli_out = subprocess.check_output([sys.executable, "-m", "examples_utils.benchmarks.notebook_utils", str(notebook_path), str(notebook_path.parent)])
+    cli_out = subprocess.check_output([
+        sys.executable, "-m", "examples_utils.benchmarks.notebook_utils",
+        str(notebook_path),
+        str(notebook_path.parent)
+    ])
     std_streams = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
 
     # There are slightly different newlines from the cli and the function
@@ -29,6 +35,7 @@ def test_cli_equivalence():
 
 class TestNotebook2Cmd:
     """Test that conversion from notebook to variant is as expected"""
+
     def test_no_op_if_not_there(self):
         variant = {"cmd": "poprun"}
         variant_out = process_notebook_to_command(copy.deepcopy(variant))
@@ -42,11 +49,21 @@ class TestNotebook2Cmd:
         with pytest.raises(ValueError, match="Invalid combination of entries"):
             process_notebook_to_command(variant)
 
-
     @pytest.mark.parametrize("variant_factory", [
-        lambda file: {"notebook": {"file": file},},
-        lambda file: {"notebook": {"file": file, "working_directory": file.parent},},
-        lambda file: {"notebook": file,},
+        lambda file: {
+            "notebook": {
+                "file": file
+            },
+        },
+        lambda file: {
+            "notebook": {
+                "file": file,
+                "working_directory": file.parent
+            },
+        },
+        lambda file: {
+            "notebook": file,
+        },
     ])
     def test_replaces_notebook(self, variant_factory):
         notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
@@ -65,9 +82,7 @@ notebook_benchmark:
     notebook:
         file: {SAMPLE_NOTEBOOK}
     """)
-    out = subprocess.check_output([
-        "python3", "-m", "examples_utils", "benchmark", "--spec", str(yaml_file)
-    ])
+    out = subprocess.check_output(["python3", "-m", "examples_utils", "benchmark", "--spec", str(yaml_file)])
     assert "PASSED notebook_benchmark::notebook_benchmark" in out.decode()
 
 

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+from examples_utils.benchmarks import notebook_utils
+
+
+TEST_DIRECTORY = Path(__file__).resolve().parent
+
+def test_notebook_runner_captures_outputs():
+    notebook_path = TEST_DIRECTORY / "test_files/sample.ipynb"
+    stdstreams, _ = notebook_utils.run_notebook(notebook_path, notebook_path.parent)
+    assert "Notebook was run" in stdstreams
+    assert isinstance(stdstreams, str)
+
+
+if __name__ == "__main__":
+    test_notebook_runner_captures_outputs()

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -35,6 +35,7 @@ def test_cli_equivalence():
 
 class TestNotebook2Cmd:
     """Test that conversion from notebook to variant is as expected"""
+
     def test_no_op_if_not_there(self):
         variant = {"cmd": "poprun"}
         variant_out = process_notebook_to_command(copy.deepcopy(variant))

--- a/tests/test_requirements_variants.py
+++ b/tests/test_requirements_variants.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+
+from pathlib import Path
+import sys
+from examples_utils.testing import test_commands
+
+import pytest
+
+ROOT_REPOSITORY = Path(__file__).resolve().parents[1]
+
+
+@pytest.fixture
+def virtual_env(tmp_path: Path) -> str:
+    venv_folder = tmp_path / "venv"
+    test_commands.run_command_fail_explicitly(["virtualenv", "-p", f"{sys.executable}", f"{venv_folder}"], ".")
+    script = tmp_path / "run-in-venv"
+    script.write_text(f"""#!/bin/bash
+source {venv_folder}/bin/activate
+python $@
+    """, encoding="ascii")
+    test_commands.run_command_fail_explicitly(["chmod", "+x", str(script)])
+    return str(script)
+
+
+class TestJupyterRequirements:
+    def run_sample_notebook(self, tmp_path: Path, virtual_env: Path):
+        yaml_file = tmp_path / "sample.yaml"
+        yaml_file.write_text(f"""
+notebook_benchmark:
+    generated: true
+    notebook:
+        file: {ROOT_REPOSITORY}/tests/test_files/sample.ipynb
+        """)
+        print(test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "list"]))
+        return test_commands.run_command_fail_explicitly(
+            [virtual_env, "-m", "examples_utils", "benchmark", "--spec",
+             str(yaml_file)],
+            ".",
+        )
+
+    def test_notebook_works(self, tmp_path, virtual_env):
+        """Install the package with `pip install examples-utils[jupyter]`"""
+        test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "install", f"{ROOT_REPOSITORY}[jupyter]"],
+                                                  ".")
+        out = self.run_sample_notebook(tmp_path, virtual_env)
+        assert "PASSED notebook_benchmark::notebook_benchmark" in out
+
+    def test_notebook_fails(self, tmp_path, virtual_env):
+        """The normal requirements should not install what is required to run a notebook
+        it should fail."""
+        test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "install", f"{ROOT_REPOSITORY}"], ".")
+        with pytest.raises(Exception, match=r"needs to have been installed with the \[jupyter\]"):
+            out = self.run_sample_notebook(tmp_path, virtual_env)
+
+
+def test_normal_requirements_python_file(tmp_path, virtual_env):
+    test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "install", f"{ROOT_REPOSITORY}"], ".")
+    python_script = tmp_path / "script.py"
+    python_script.write_text("print('Hello world!')")
+    yaml_file = tmp_path / "sample.yaml"
+    yaml_file.write_text(f"""
+script_benchmark:
+    generated: true
+    cmd: python3 {python_script}
+    """)
+    print(test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "list"]))
+    out = test_commands.run_command_fail_explicitly(
+        [virtual_env, "-m", "examples_utils", "benchmark", "--spec",
+         str(yaml_file)],
+        ".",
+    )
+    assert "PASSED script_benchmark::script_benchmark" in out


### PR DESCRIPTION
Implements benchmarks which are defined by a notebook in YAML as:

```yaml
notebook_benchmark:
    generated: true
    requirements_file: path/to/requirements.txt
    notebook:
        file: <path>
```

This functionality is tested in `test_notebook_utils.py::test_end_2_end`.

This introduces a couple of backward compatible tweaks to the YAML definition:

- support for an explicit `generated` and `synthetic` field
- supports variants of the requirements for jupyter to avoid dragging enormous dependencies in every app.
  - [x] add a test for that
- Add `testing.test_commands` which includes a helper from the tutorials repository which prints errors very explicitely (useful in pytest)