### PR TITLE
Re-run notebooks if failure is due to missing requirements

### DIFF
--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import os
 import argparse
+import subprocess
+import sys
 
 try:
     import nbformat
@@ -31,8 +33,11 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     exporter = OutputExporter()
     try:
         ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-    except CellExecutionError:
+    except CellExecutionError as error:
+
         output, _ = exporter.from_notebook_node(nb)
+        if "ModuleNotFoundError" in str(error) or "ModuleNotFoundError" in output:
+            return str(subprocess.check_output([sys.executable, *sys.argv]))
         print(output)
         raise
     output, _ = exporter.from_notebook_node(nb)

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -1,8 +1,6 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import os
 import argparse
-import subprocess
-import sys
 
 try:
     import nbformat
@@ -33,11 +31,8 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     exporter = OutputExporter()
     try:
         ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-    except CellExecutionError as error:
-
+    except CellExecutionError:
         output, _ = exporter.from_notebook_node(nb)
-        if "ModuleNotFoundError" in str(error) or "ModuleNotFoundError" in output:
-            return str(subprocess.check_output([sys.executable, *sys.argv]))
         print(output)
         raise
     output, _ = exporter.from_notebook_node(nb)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -50,7 +50,7 @@ from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 logger = logging.getLogger()
 
 
-def reattempt_run(variant, output, err, exitcode) -> Union[bool, str]:
+def should_reattempt_benchmark(variant, output, err, exitcode) -> Union[bool, str]:
     if "Timeout" in err:
         return False
     is_a_notebook = "examples_utils.benchmarks.notebook_utils" in variant["cmd"]
@@ -252,8 +252,8 @@ def run_benchmark_variant(
         subprocess.check_output([sys.executable, "-m", "pip", "install", "-r", str(reqs)])
 
     logger.info(f"Start test: {start_time}")
-    attempt_run = True
-    while attempt_run:
+    need_to_run = True
+    while need_to_run:
         stdout, stderr, exitcode = run_and_monitor_progress(
             cmd,
             listener,
@@ -261,7 +261,7 @@ def run_benchmark_variant(
             cwd=cwd,
             env=env,
         )
-        attempt_run = reattempt_run(benchmark_dict, stdout, stderr, exitcode)
+        need_to_run = should_reattempt_benchmark(benchmark_dict, stdout, stderr, exitcode)
         if attempt_run:
             logger.info(f"Re-running benchmark because: {attempt_run}")
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -53,8 +53,8 @@ logger = logging.getLogger()
 def reattempt_run(variant, output, err, exitcode) -> Union[bool, str]:
     if "Timeout" in err:
         return False
-
-    if "notebook" in variant and "ModuleNotFoundError" in err and exitcode != 0:
+    is_a_notebook = "examples_utils.benchmarks.notebook_utils" in variant["cmd"]
+    if is_a_notebook and "ModuleNotFoundError" in err and exitcode != 0:
         if "Successfully installed" in output:
             return "Notebook has installed some packages, need to restart kernel"
 
@@ -269,6 +269,7 @@ def run_benchmark_variant(
             Path("./final_out.log").write_text(stdout)
             Path("./final_err.log").write_text(stderr)
             Path("./final_bench_dict.log").write_text(json.dumps(benchmark_dict))
+
     end_time = datetime.now()
     total_runtime = (end_time - start_time).total_seconds()
     logger.info(f"End test: {end_time}")

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -264,11 +264,6 @@ def run_benchmark_variant(
         attempt_run = reattempt_run(benchmark_dict, stdout, stderr, exitcode)
         if attempt_run:
             logger.info(f"Re-running benchmark because: {attempt_run}")
-        else:
-            logger.info(f"Not reattempting run: {attempt_run}")
-            Path("./final_out.log").write_text(stdout)
-            Path("./final_err.log").write_text(stderr)
-            Path("./final_bench_dict.log").write_text(json.dumps(benchmark_dict))
 
     end_time = datetime.now()
     total_runtime = (end_time - start_time).total_seconds()

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -262,8 +262,8 @@ def run_benchmark_variant(
             env=env,
         )
         need_to_run = should_reattempt_benchmark(benchmark_dict, stdout, stderr, exitcode)
-        if attempt_run:
-            logger.info(f"Re-running benchmark because: {attempt_run}")
+        if need_to_run:
+            logger.info(f"Re-running benchmark because: {need_to_run}")
 
     end_time = datetime.now()
     total_runtime = (end_time - start_time).total_seconds()

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -264,6 +264,11 @@ def run_benchmark_variant(
         attempt_run = reattempt_run(benchmark_dict, stdout, stderr, exitcode)
         if attempt_run:
             logger.info(f"Re-running benchmark because: {attempt_run}")
+        else:
+            logger.info(f"Not reattempting run: {attempt_run}")
+            Path("./final_out.log").write_text(stdout)
+            Path("./final_err.log").write_text(stderr)
+            Path("./final_bench_dict.log").write_text(json.dumps(benchmark_dict))
     end_time = datetime.now()
     total_runtime = (end_time - start_time).total_seconds()
     logger.info(f"End test: {end_time}")


### PR DESCRIPTION
It is possible for notebooks to install requirements directly during the execution, however doing so might require the notebook kernel to be restarted. This is acceptable but we want the tests of notebooks so we re-attempt a notebook while:

- A successful installation of packages is detected
- Failures are due to missing modules