### PR TITLE
Adding a check before commiting to uploading weights

### DIFF
--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -74,8 +74,8 @@ def check_env(args: ArgumentParser, benchmark_name: str, cmd: str):
         # Determine if wandb login has not been done already
         netrc_path = Path(os.environ["HOME"], ".netrc")
         if netrc_path.exists() and os.stat(Path(os.environ["HOME"], ".netrc")).st_size == 0:
+            logger.warn("wandb appears to not have been logged in. Checking for environment variables to be used instead...")
             missing_env_vars.extend([env_var for env_var in WANDB_VARS.keys() if os.getenv(env_var) is None])
-            logger.warn("wandb has not been logged in. Checking for environment variables to be used instead...")
 
     # Check AWSCLI env vars if required
     if "s3" in args.upload_checkpoints:

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -74,7 +74,8 @@ def check_env(args: ArgumentParser, benchmark_name: str, cmd: str):
         # Determine if wandb login has not been done already
         netrc_path = Path(os.environ["HOME"], ".netrc")
         if netrc_path.exists() and os.stat(Path(os.environ["HOME"], ".netrc")).st_size == 0:
-            logger.warn("wandb appears to not have been logged in. Checking for environment variables to be used instead...")
+            logger.warn("wandb appears to not have been logged in. Checking "
+                        "for environment variables to be used instead...")
             missing_env_vars.extend([env_var for env_var in WANDB_VARS.keys() if os.getenv(env_var) is None])
 
     # Check AWSCLI env vars if required

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -190,6 +190,16 @@ def upload_checkpoints(upload_targets: list, checkpoint_path: Path, benchmark_pa
 
     """
 
+    # Get confirmation user wants to upload checkpoint (post results), else exit
+    upload_confirmed = input("Upload checkpoints? (y/n): ")
+    while upload_confirmed not in {"y", "n"}:
+        upload_confirmed = input("Please enter either y (yes) or n (no): ")
+
+    if upload_confirmed != "y":
+        logger.warn(f"Checkpoint uploading was refused by user input, skipping "
+                    f"uploading checkpoints at {checkpoint_path}")
+        return
+
     checkpoint_path = str(checkpoint_path)
 
     if "wandb" in upload_targets:


### PR DESCRIPTION
Adds a check that asks for user input before commiting to a checkpoint upload. This is to prevent collapsed runs from being uploaded automatically.