### PR TITLE
Refactor run benchmark to support extension

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -3,7 +3,7 @@ import logging
 import os
 import re
 import subprocess
-from argparse import ArgumentParser
+from argparse import Namespace
 from pathlib import Path
 
 # Get the module logger
@@ -121,7 +121,7 @@ def get_benchmark_variants(benchmark_name: str, benchmark_dict: dict) -> list:
 def formulate_benchmark_command(
         benchmark_dict: dict,
         variant_dict: dict,
-        args: ArgumentParser,
+        args: Namespace,
 ) -> str:
     """Create the actual command to be run from an unformatted string.
 
@@ -130,7 +130,7 @@ def formulate_benchmark_command(
             pre-formating to fill in variables
         variant_dict (dict): Variant specification, containing all the actual
             values of the variables to be used to construct this command
-        args (ArgumentParser): Arguments passed to this benchmarking run
+        args (Namespace): Arguments passed to this benchmarking run
 
     Returns:
         cmd (str): The final, formatted command to be run

--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -5,7 +5,8 @@ import os
 import re
 import sys
 import subprocess
-from argparse import ArgumentParser
+import argparse
+import argparse
 from pathlib import Path
 
 # Get the module logger
@@ -40,11 +41,11 @@ AWSCLI_VARS = {
 }
 
 
-def check_env(args: ArgumentParser, benchmark_name: str, cmd: str):
+def check_env(args: argparse.Namespace, benchmark_name: str, cmd: str):
     """Check if environment has been correctly set up prior to running.
 
     Args:
-        args (ArgumentParser): CLI arguments provided to this benchmarking run
+        args (argparse.Namespace): CLI arguments provided to this benchmarking run
         benchmark_name (str): The name of the benchmark being run
         cmd (str): The command being run
 
@@ -131,7 +132,7 @@ def get_mpinum(command: str) -> int:
 
     Returns:
         mpinum (int): Number of processes passed to mpirun
-    
+
     """
 
     m = re.search(r"mpirun.+--np.(\d*) ", command)
@@ -143,16 +144,16 @@ def get_mpinum(command: str) -> int:
     return mpinum
 
 
-def infer_paths(args: ArgumentParser, benchmark_dict: dict) -> ArgumentParser:
+def infer_paths(args: argparse.Namespace, benchmark_dict: dict) -> argparse.Namespace:
     """Infer paths to key directories based on argument and environment info.
 
     Args:
-        args (ArgumentParser): The arguments passed to this benchmarking run
+        args (argparse.Namespace): The arguments passed to this benchmarking run
         benchmark_dict (dict): The parameters for a particular benchmark
-    
+
     Returns:
-        args (ArgumentParser): args, but with additional paths attributes added
-    
+        args (argparse.Namespace): args, but with additional paths attributes added
+
     """
 
     spec_path = benchmark_dict["benchmark_path"]
@@ -205,13 +206,13 @@ def merge_environment_variables(new_env: dict, benchmark_spec: dict) -> dict:
     """Merge existing environment variables with new ones in the benchmark.
 
     Args:
-        new_env (dict): The new environment variables state to merge into 
+        new_env (dict): The new environment variables state to merge into
             current state
         benchmark_dict (dict): The benchmark entry itself in the yaml file
 
     Returns:
         existing_env (dict): Merged environment state to use for benchmarking
-    
+
     """
 
     # Build and log the additional ENV variables
@@ -231,15 +232,15 @@ def merge_environment_variables(new_env: dict, benchmark_spec: dict) -> dict:
     return existing_env
 
 
-def preprocess_args(args: ArgumentParser) -> ArgumentParser:
+def preprocess_args(args: argparse.Namespace) -> argparse.Namespace:
     """Resolve any gaps or inconsistencies in the arguments provided.
 
     Args:
-        args (ArgumentParser): The arguments passed to this benchmarking run
+        args (argparse.Namespace): The arguments passed to this benchmarking run
 
     Returns:
-        args (ArgumentParser): args, but with any issues resolved
-    
+        args (argparse.Namespace): args, but with any issues resolved
+
     """
 
     # Force allow-wandb if user wants to upload checkpoints to wandb

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -21,12 +21,12 @@ except:
 logger = logging.getLogger(__name__)
 
 
-def configure_logger(args: argparse.ArgumentParser):
+def configure_logger(args: argparse.Namespace):
     """Setup the benchmarks runner logger
 
     Args:
         args (argparse.ArgumentParser): Argument parser used for benchmarking
-    
+
     """
 
     # Setup dir
@@ -55,7 +55,7 @@ def print_benchmark_summary(results: dict):
 
     Args:
         results (dict): Benchmark results dict to create summary from
-    
+
     """
 
     # Print PASS/FAIL statements
@@ -82,7 +82,7 @@ def get_latest_checkpoint_path(checkpoint_root_dir: Path, variant_cmd: str) -> P
     Args:
         checkpoint_root_dir (Path): The path to the benchmarking dir
         variant_cmd (str): The command used for this model run (benchmark)
-    
+
     Returns:
         latest_checkpoint_path (Path): The directory containing all checkpoints
             as specified in the benchmarks.yml (or 'None' if this is not found.)
@@ -179,7 +179,7 @@ def save_results(log_dir: str, additional_metrics: bool, results: dict):
 
 def upload_checkpoints(upload_targets: list, checkpoint_path: Path, benchmark_path: str, checkpoint_dir_depth: int,
                        run_name: str, stderr: str):
-    """Upload checkpoints from model run to 
+    """Upload checkpoints from model run to
 
     Args:
         upload_targets (list): Which targets/locations to upload checkpoints to

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -402,11 +402,11 @@ def process_notebook_to_command(variant, name="unknown"):
     return variant
 
 
-def run_benchmarks(args: argparse.ArgumentParser):
+def run_benchmarks(args: argparse.Namespace):
     """Run benchmarks.
 
     Args:
-        args (argparse.ArgumentParser): Arguments passed to run the benchmarks
+        args (argparse.Namespace): Arguments passed to run the benchmarks
             with
 
     """

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -53,7 +53,6 @@ from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 # Get the module logger
 logger = logging.getLogger()
 
-
 BenchmarkDict = Dict
 # A dictionary which defines a benchmark
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -12,7 +12,7 @@ from collections import OrderedDict
 from datetime import datetime, timedelta
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Tuple
+from typing import Tuple, List, Dict
 
 import yaml
 from examples_utils.benchmarks.command_utils import (
@@ -52,6 +52,10 @@ from examples_utils.benchmarks.profiling_utils import add_profiling_vars
 
 # Get the module logger
 logger = logging.getLogger()
+
+
+BenchmarkDict = Dict
+# A dictionary which defines a benchmark
 
 
 def should_reattempt_benchmark(variant, output, err, exitcode) -> Union[bool, str]:
@@ -409,16 +413,21 @@ def run_benchmarks(args: argparse.ArgumentParser):
 
     # Preprocess args to resolve any inconsistencies or cover up any gaps
     args = preprocess_args(args)
-
-    # Resolve paths to benchmarks specs
     args.spec = [str(Path(file).resolve()) for file in args.spec]
+    spec = parse_benchmark_specs(args.spec)
+    run_benchmarks_from_spec(spec, args)
 
-    spec_files = ",".join([str(sf) for sf in args.spec if ".yml" in str(sf)])
-    logger.info(f"Running benchmark suite: '{spec_files}'")
+
+def parse_benchmark_specs(spec_files: List[str]):
+    """Parses a list of benchmark spec files into benchmarks definition"""
+    # Resolve paths to benchmarks specs
+
+    spec_files_str = ",".join([str(sf) for sf in spec_files if ".yml" in str(sf)])
+    logger.info(f"Running benchmark suite: '{spec_files_str}'")
 
     # Load all benchmark configs from all files given
-    spec = {}
-    for spec_file in args.spec:
+    spec: Dict[str, BenchmarkDict] = {}
+    for spec_file in spec_files:
         logger.debug(f"Examining: '{spec_file}'")
         found_benchmarks = yaml.load(open(spec_file).read(), Loader=yaml.FullLoader)
 
@@ -426,7 +435,10 @@ def run_benchmarks(args: argparse.ArgumentParser):
         for _, v in found_benchmarks.items():
             v["benchmark_path"] = spec_file
         spec.update(found_benchmarks)
+    return spec
 
+
+def run_benchmarks_from_spec(spec: Dict[str, BenchmarkDict], args: argparse.Namespace):
     results = {}
     output_log_path = Path(args.log_dir, "output.log")
     with open(output_log_path, "w", buffering=1) as listener:
@@ -523,6 +535,7 @@ def run_benchmarks(args: argparse.ArgumentParser):
     print_benchmark_summary(results)
 
     save_results(args.log_dir, args.additional_metrics, results)
+    return results
 
 
 def benchmarks_parser(parser: argparse.ArgumentParser):


### PR DESCRIPTION
This is a small refactor of the `run_benchmarks` function to make the underlying functionality available.

It should be sufficient to allow the badly thought out features of #46 to be extracted into a separate command.