### PR TITLE
Generate IPU monitoring logs during benchmark

### DIFF
--- a/examples_utils/benchmarks/monitoring_utils.py
+++ b/examples_utils/benchmarks/monitoring_utils.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+from typing import List, Dict
+from pathlib import Path
+import json
+
+try:
+    import pandas as pd
+    # while not used explicitely need to check
+    import matplotlib as _
+except (ImportError, ModuleNotFoundError) as error:
+    from . import _incorrect_requirement_variant_error
+    raise _incorrect_requirement_variant_error from error
+
+
+def process_monitoring_file(file):
+    file_content: List[Dict[str, Dict]] = [json.loads(l) for l in file.read_text().splitlines()]
+    for entry in file_content:
+        for i, card in enumerate(entry.pop("cards")):
+            entry[f"cards.{i}"] = card
+            for j, ipu in enumerate(card.pop("ipus")):
+                card[f"ipus.{j}"] = ipu
+    df = pd.json_normalize(file_content)
+    pid_columns = [c for c in df.columns if ".PID" in c]
+    df["ipus_in_use"] = df[pid_columns].notna().sum(axis="columns")
+    df = df.set_index(pd.to_datetime(df["timestamp"], format="%Y-%m-%d-%H.%M.%S.%f"))
+    return df
+
+
+def plot_ipu_usage(directory: Path):
+    directory = Path(directory)
+    monitoring_files = [*directory.rglob("*.jsonl")]
+    ax = None
+    for file in monitoring_files:
+        df = process_monitoring_file(file)
+        ax = df.plot(y="ipus_in_use", ax=ax, label=file.parent.name)
+
+    ax.set_ylabel("Number of IPUs in use")
+    leg = ax.legend()
+    leg.set_bbox_to_anchor((1, -0.25))
+    ax.figure.savefig(directory / "ipu_usage.png", dpi=300)
+    return ax.figure

--- a/examples_utils/benchmarks/monitoring_utils.py
+++ b/examples_utils/benchmarks/monitoring_utils.py
@@ -6,7 +6,7 @@ import json
 try:
     import pandas as pd
     # while not used explicitely need to check
-    import matplotlib as _
+    from matplotlib import pyplot as plt
 except (ImportError, ModuleNotFoundError) as error:
     from . import _incorrect_requirement_variant_error
     raise _incorrect_requirement_variant_error from error
@@ -29,7 +29,7 @@ def process_monitoring_file(file):
 def plot_ipu_usage(directory: Path):
     directory = Path(directory)
     monitoring_files = [*directory.rglob("*.jsonl")]
-    ax = None
+    fig, ax = plt.subplots(1, 1)
     for file in monitoring_files:
         df = process_monitoring_file(file)
         ax = df.plot(y="ipus_in_use", ax=ax, label=file.parent.name)
@@ -37,5 +37,5 @@ def plot_ipu_usage(directory: Path):
     ax.set_ylabel("Number of IPUs in use")
     leg = ax.legend()
     leg.set_bbox_to_anchor((1, -0.25))
-    ax.figure.savefig(directory / "ipu_usage.png", dpi=300)
+    fig.savefig(directory / "ipu_usage.png", dpi=300, bbox_extra_artists=(leg, ), bbox_inches='tight')
     return ax.figure

--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -69,7 +69,7 @@ def install_patched_requirements(requirements_file: Union[str, Path], listener: 
     original_requirements = requirements_file.read_text()
     requirements_file.write_text("\n".join(l for l in original_requirements.splitlines() if "examples-utils" not in l))
     cmd = [sys.executable, "-m", "pip", "install", "-r", str(requirements_file)]
-    out, err, exit_code = run_and_monitor_progress(cmd, listener)
+    out, err, exit_code, _ = run_and_monitor_progress(cmd, listener, monitor_ipus=False)
     if exit_code:
         err = (f"Installation of pip packages in file {requirements_file} failed with stderr: {err}.")
         logger.error(err)
@@ -94,7 +94,7 @@ def install_apt_packages(requirements_file_or_list: Union[str, Path, List[str]],
         ["apt", "update", "-y"],
         ["apt", "install", "-y", *requirements_list],
     ]:
-        out, err, exit_code = run_and_monitor_progress(cmd, listener)
+        out, err, exit_code, _ = run_and_monitor_progress(cmd, listener, monitor_ipus=False)
         if exit_code:
             err = (f"System packages installation failed with stderr: {err}.")
             logger.error(err)

--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -30,6 +30,8 @@ class Repository(NamedTuple):
         """Clones and checkouts the correct ref of the origin"""
         if cloning_directory is None:
             cloning_directory = Path(".").resolve() / "clones"
+        else:
+           cloning_directory = Path(cloning_directory).resolve()
         # Treat the origin as a folder, if it doesn't exist it's a URL to clone
         repo_folder = Path(self.origin)
         if not repo_folder.exists():

--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -31,7 +31,7 @@ class Repository(NamedTuple):
         if cloning_directory is None:
             cloning_directory = Path(".").resolve() / "clones"
         else:
-           cloning_directory = Path(cloning_directory).resolve()
+            cloning_directory = Path(cloning_directory).resolve()
         # Treat the origin as a folder, if it doesn't exist it's a URL to clone
         repo_folder = Path(self.origin)
         if not repo_folder.exists():

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -384,11 +384,12 @@ def run_benchmark_variant(
             stderr=stderr,
         )
 
+    variant_logdir = outlog_path.parent
     if not args.submit_on_slurm:
         with open(outlog_path, "w") as f:
             f.write(stdout)
         if monitor_log:
-            with open(outlog_path.parent / "ipu-monitor.jsonl", "w") as f:
+            with open(variant_logdir / "ipu-monitor.jsonl", "w") as f:
                 f.writelines(monitor_log)
             plot_ipu_usage(outlog_path.parent)
         with open(errlog_path, "w") as f:
@@ -407,6 +408,10 @@ def run_benchmark_variant(
         "compilation_end_time": str(results["total_compiling_time"]["mean"]),
         "test_duration": str(total_runtime),
         "exitcode": exitcode,
+        "log_paths": {
+            "out": str(outlog_path),
+            "err": str(errlog_path)
+        },
     }
 
     # These failure points are not caught normally, check here
@@ -416,6 +421,10 @@ def run_benchmark_variant(
     ]
     if any(possible_failure_points) and exitcode == 0:
         variant_result["exitcode"] = 1
+
+    if not args.submit_on_slurm:
+        with open(variant_logdir / "variant_result.json", "r") as f:
+            json.dump(variant_result, f)
 
     return variant_result
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -55,7 +55,11 @@ def should_reattempt_benchmark(variant, output, err, exitcode) -> Union[bool, st
     return False
 
 
-def run_and_monitor_progress(cmd: list, v: TextIOWrapper, timeout: int = None, monitor_ipus: bool=True, **kwargs) -> Tuple[str, str, int, List[str]]:
+def run_and_monitor_progress(cmd: list,
+                             listener: TextIOWrapper,
+                             timeout: int = None,
+                             monitor_ipus: bool = True,
+                             **kwargs) -> Tuple[str, str, int, List[str]]:
     """Run the benchmark monitor progress.
 
     Args:
@@ -108,16 +112,15 @@ def run_and_monitor_progress(cmd: list, v: TextIOWrapper, timeout: int = None, m
         listener.write(b.decode())
         listener.flush()
 
-
     def monitor_thread():
         while proc.is_alive():
             try:
-                ipu_log_line = json.dumps(json.loads(subprocess.check_output(["gc-monitor", "--json"])))
+                timestamp = datetime.now().strftime("%Y-%m-%d-%H.%M.%S.%f")
+                ipu_log_line = json.dumps({"timestamp": timestamp, **json.loads(subprocess.check_output(["gc-monitor", "--json"]))})
                 ipu_monitoring.append(ipu_log_line)
                 time.sleep(5)
             except:
                 pass
-
 
     t = threading.Thread(target=proc_thread, name="proc_thread")
     t.start()

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -112,19 +112,18 @@ def run_and_monitor_progress(cmd: list,
         listener.write(b.decode())
         listener.flush()
 
-    def monitor_thread():
-        while proc.is_alive():
-            try:
-                timestamp = datetime.now().strftime("%Y-%m-%d-%H.%M.%S.%f")
-                ipu_log_line = json.dumps({"timestamp": timestamp, **json.loads(subprocess.check_output(["gc-monitor", "--json"]))})
-                ipu_monitoring.append(ipu_log_line)
-                time.sleep(5)
-            except:
-                pass
-
     t = threading.Thread(target=proc_thread, name="proc_thread")
     t.start()
     if monitor_ipus:
+        def monitor_thread():
+            while t.is_alive():
+                try:
+                    timestamp = datetime.now().strftime("%Y-%m-%d-%H.%M.%S.%f")
+                    ipu_log_line = json.dumps({"timestamp": timestamp, **json.loads(subprocess.check_output(["gc-monitor", "--json"]))})
+                    ipu_monitoring.append(ipu_log_line)
+                    time.sleep(5)
+                except:
+                    pass
         t_monitor = threading.Thread(target=monitor_thread, name="monitor_thread")
         t_monitor.start()
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -43,6 +43,7 @@ try:
     # so we define a dummy function when the dependencies are not available.
     from .monitoring_utils import plot_ipu_usage
 except (ImportError, ModuleNotFoundError) as error:
+
     def plot_ipu_usage(*args, **kwargs):
         """Does nothing install the package with examples-utils[jupyter] to
         plot IPU usage during benchmarks"""

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -180,7 +180,7 @@ def run_benchmark_variant(
         variant_dict: dict,
         benchmark_dict: dict,
         listener: TextIOWrapper,
-        args: argparse.ArgumentParser,
+        args: argparse.Namespace,
 ) -> dict:
     """Run a variant and collect results.
 
@@ -192,7 +192,7 @@ def run_benchmark_variant(
         benchmark_dict (dict): The benchmark definition from the yaml file
         listener (TextIOWrapper): Open file to collect stdout/stderr from the
             process running the variant
-        args (argparse.ArgumentParser): Arguments passed to this script
+        args (argparse.Namespace): Arguments passed to this script
 
     Returns:
         variant_result (dict): The results from this variants run
@@ -280,6 +280,7 @@ def run_benchmark_variant(
     logger.info(f"Start test: {start_time}")
     need_to_run = True
     monitor_log = []
+    exitcode = 0
     while need_to_run:
         if args.submit_on_slurm:
             stdout, stderr, exitcode = run_and_monitor_progress_on_slurm(listener=listener, **slurm_config)
@@ -386,9 +387,9 @@ def run_benchmark_variant(
     if not args.submit_on_slurm:
         with open(outlog_path, "w") as f:
             f.write(stdout)
-        with open(outlog_path.parent / "ipu-monitor.jsonl", "w") as f:
-            f.writelines(monitor_log)
         if monitor_log:
+            with open(outlog_path.parent / "ipu-monitor.jsonl", "w") as f:
+                f.writelines(monitor_log)
             plot_ipu_usage(outlog_path.parent)
         with open(errlog_path, "w") as f:
             f.write(stderr)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -120,7 +120,7 @@ def run_and_monitor_progress(cmd: list,
                 try:
                     timestamp = datetime.now().strftime("%Y-%m-%d-%H.%M.%S.%f")
                     ipu_log_line = json.dumps({"timestamp": timestamp, **json.loads(subprocess.check_output(["gc-monitor", "--json"]))})
-                    ipu_monitoring.append(ipu_log_line)
+                    ipu_monitoring.append(f"{ipu_log_line}\n")
                     time.sleep(5)
                 except:
                     pass

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -115,15 +115,20 @@ def run_and_monitor_progress(cmd: list,
     t = threading.Thread(target=proc_thread, name="proc_thread")
     t.start()
     if monitor_ipus:
+
         def monitor_thread():
             while t.is_alive():
                 try:
                     timestamp = datetime.now().strftime("%Y-%m-%d-%H.%M.%S.%f")
-                    ipu_log_line = json.dumps({"timestamp": timestamp, **json.loads(subprocess.check_output(["gc-monitor", "--json"]))})
+                    ipu_log_line = json.dumps({
+                        "timestamp": timestamp,
+                        **json.loads(subprocess.check_output(["gc-monitor", "--json"]))
+                    })
                     ipu_monitoring.append(f"{ipu_log_line}\n")
                     time.sleep(5)
                 except:
                     pass
+
         t_monitor = threading.Thread(target=monitor_thread, name="monitor_thread")
         t_monitor.start()
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -281,6 +281,7 @@ def run_benchmark_variant(
     need_to_run = True
     monitor_log = []
     exitcode = 0
+    stdout = stderr = ""
     while need_to_run:
         if args.submit_on_slurm:
             stdout, stderr, exitcode = run_and_monitor_progress_on_slurm(listener=listener, **slurm_config)
@@ -384,12 +385,11 @@ def run_benchmark_variant(
             stderr=stderr,
         )
 
-    variant_logdir = outlog_path.parent
     if not args.submit_on_slurm:
         with open(outlog_path, "w") as f:
             f.write(stdout)
         if monitor_log:
-            with open(variant_logdir / "ipu-monitor.jsonl", "w") as f:
+            with open(variant_log_dir / "ipu-monitor.jsonl", "w") as f:
                 f.writelines(monitor_log)
             plot_ipu_usage(outlog_path.parent)
         with open(errlog_path, "w") as f:
@@ -423,7 +423,7 @@ def run_benchmark_variant(
         variant_result["exitcode"] = 1
 
     if not args.submit_on_slurm:
-        with open(variant_logdir / "variant_result.json", "r") as f:
+        with open(variant_log_dir / "variant_result.json", "w") as f:
             json.dump(variant_result, f)
 
     return variant_result

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -1,6 +1,6 @@
 ipykernel>=5.5.6
 nbconvert>=6.0.7
 nbformat>=5.1.3
-gitpython>=3.1.29
+gitpython>=3.1
 pandas>=1
 matplotlib>=3

--- a/requirements-jupyter.txt
+++ b/requirements-jupyter.txt
@@ -2,3 +2,5 @@ ipykernel>=5.5.6
 nbconvert>=6.0.7
 nbformat>=5.1.3
 gitpython>=3.1.29
+pandas>=1
+matplotlib>=3

--- a/tests/test_notebook_utils.py
+++ b/tests/test_notebook_utils.py
@@ -97,7 +97,9 @@ notebook_benchmark:
     notebook:
         file: {SAMPLE_NOTEBOOK}
     """)
-    out = subprocess.check_output(["python3", "-m", "examples_utils", "benchmark", "--spec", str(yaml_file)])
+    out = subprocess.check_output(
+        ["python3", "-m", "examples_utils", "benchmark", "--gc-monitor", "--spec",
+         str(yaml_file)])
     assert "PASSED notebook_benchmark::notebook_benchmark" in out.decode()
 
 

--- a/tests/test_requirements_variants.py
+++ b/tests/test_requirements_variants.py
@@ -65,7 +65,7 @@ script_benchmark:
     """)
     print(test_commands.run_command_fail_explicitly([virtual_env, "-m", "pip", "list"]))
     out = test_commands.run_command_fail_explicitly(
-        [virtual_env, "-m", "examples_utils", "benchmark", "--spec",
+        [virtual_env, "-m", "examples_utils", "benchmark", "--gc-monitor", "--spec",
          str(yaml_file)],
         ".",
     )


### PR DESCRIPTION
Adds a `--gc-monitor` to the benchmark utility. It runs gc-monitor every 5 seconds and stores it in the benchmark logs folder in a `jsonl` file (a list of json entries).

If examples-utils has been installed with the `examples-utils[jupyter]` variant of requirements it will also output pngs plotting the IPU usage during the benchmarks.

Pandas and matplotlib are only added as dependencies to the `jupyter` variant of requirements to avoid installing it into every application of `graphcore/examples`

Once processed the data looks like this:

![Screenshot 2022-11-18 at 13 36 21](https://user-images.githubusercontent.com/18074599/202717545-37866c34-c715-41d2-996d-a1f785a4e974.png)
