### PR TITLE
Allow customisation of metrics and CSV reports from client code

### DIFF
--- a/examples_utils/__init__.py
+++ b/examples_utils/__init__.py
@@ -5,4 +5,6 @@ from .parsing import *
 from .load_lib_utils import *
 from .benchmarks import *
 
+from .benchmarks.custom_metrics import register_custom_metric
+
 __version__ = "0.1.0"

--- a/examples_utils/benchmarks/custom_metrics.py
+++ b/examples_utils/benchmarks/custom_metrics.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+""" This module lets you register custom metrics to let you
+define arbitrary ways in which the standard output, the standard
+error and the exit code of a benchmark will be parsed.
+
+In order to define a new metric:
+
+ 1. Write new metric functions in a python file ``my_metric.py``
+ 2. Register those metrics with the ``register_custom_metric`` function
+ 3. Run the benchmarks with the additional argument ``--custom-metrics-files=my_metric.py``
+
+Example content of ``my_metric.py``
+
+```
+from examples_utils import register_custom_metric
+
+# Arbitrary metric function it must have a similar signature
+def log_lengths(stdout: str, stderr: str, exitcode: int):
+    return dict(stdout=len(stdout), stderr=len(stderr))
+
+
+# Call this function to declare the metric to examples utils
+# it will appear in the final results directory under the name
+# passed as a first argument.
+register_custom_metric("log_lengths", log_lengths)
+```
+
+"""
+from typing import List, Callable, Optional, Any, Dict, Union
+import logging
+import pathlib
+import importlib.util
+
+logger = logging.getLogger(__name__)
+
+MetricFunction = Callable[[str, str, int], Optional[Any]]
+
+REGISTERED_HOOKS: Dict[str, MetricFunction] = {}
+
+
+def import_metrics_hooks_files(hook_files: List[Union[str, pathlib.Path]]):
+    """Imports files which define additional metrics in python"""
+    for file in hook_files:
+        file_path = pathlib.Path(file).resolve()
+        module_name = file_path.stem
+        spec = importlib.util.spec_from_file_location(module_name, file_path)
+        if spec is None or spec.loader is None:
+            logger.warning(f"{file_path} specified as defining additional metrics could not be imported.")
+        else:
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
+            logger.info(f"Imported {module_name} from '{file_path}'")
+
+
+def register_custom_metric(name: str, function: MetricFunction):
+    """ Register a new metric function to be run during processing of the benchmark.
+    """
+    if name in REGISTERED_HOOKS:
+        logger.warning(f"Metric '{name}' multiply defined, only the last registered implementation will be executed.")
+    REGISTERED_HOOKS[name] = function
+    logger.info(f"    Registered metric hook: {name} with object: {function}")
+
+
+def process_registered_metrics(results: dict, stdout: str, stderr: str, exitcode: int):
+    """ Process the metrics registered with ``register_custom_metric``
+    """
+    for metric_name, metric_function in REGISTERED_HOOKS.items():
+        try:
+            results[metric_name] = metric_function(stdout, stderr, exitcode)
+        except Exception as error:
+            err = (f"Metric '{metric_name}' failed during execution with: {type(error).__name__} {error}")
+            logger.error(err)
+    return results

--- a/examples_utils/benchmarks/logging_utils.py
+++ b/examples_utils/benchmarks/logging_utils.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+from typing import Sequence
 import argparse
 import csv
 import json
@@ -137,7 +138,7 @@ def get_wandb_link(stderr: str) -> str:
     return wandb_link
 
 
-def save_results(log_dir: str, additional_metrics: bool, results: dict):
+def save_results(log_dir: str, additional_metrics: bool, results: dict, extra_csv_metrics: Sequence[str] = tuple()):
     """Save benchmark results into files.
 
     Args:
@@ -154,10 +155,8 @@ def save_results(log_dir: str, additional_metrics: bool, results: dict):
     # Parse summary into CSV and save in logs directory
     csv_metrics = ["throughput", "latency", "total_compiling_time"]
     if additional_metrics:
-        csv_metrics = [
-            "throughput", "latency", "total_compiling_time", "test_duration", "loss", "result", "cmd", "env",
-            "git_commit_hash"
-        ]
+        csv_metrics.extend(["test_duration", "loss", "result", "cmd", "env", "git_commit_hash"])
+    csv_metrics.extend(extra_csv_metrics)
 
     csv_filepath = Path(log_dir, "benchmark_results.csv")
     with open(csv_filepath, "w") as csv_file:

--- a/tests/test_custom_metrics.py
+++ b/tests/test_custom_metrics.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
+from pathlib import Path
+import pytest
+import logging
+import sys
+import re
+import json
+
+from examples_utils.benchmarks import custom_metrics
+from examples_utils.testing import test_commands
+
+EXPECTED_METRIC_HOOK_NAME = "log_lengths"
+
+CUSTOM_METRIC_FILE = f"""
+from examples_utils import register_custom_metric
+
+# Arbitrary metric function it must have a similar signature
+def log_lengths(stdout: str, stderr: str, exitcode: int):
+    print(f"stdout : {{stdout}}")
+    print(f"stderr : {{stderr}}")
+    return dict(stdout=len(stdout.splitlines()), stderr=len(stderr.splitlines()))
+
+
+# Call this function to declare the metric to examples utils
+# it will appear in the final results directory under the name
+# passed as a first argument.
+register_custom_metric("{EXPECTED_METRIC_HOOK_NAME}", log_lengths)
+"""
+
+
+@pytest.fixture
+def metrics_file(tmp_path: Path):
+    python_file = tmp_path / "my_metric.py"
+    python_file.write_text(CUSTOM_METRIC_FILE)
+    return python_file
+
+
+@pytest.fixture(autouse=True)
+def clean_hooks():
+    """Makes sure that no hooks are registered before we start"""
+    previous = {**custom_metrics.REGISTERED_HOOKS}
+    custom_metrics.REGISTERED_HOOKS.clear()
+    yield
+    custom_metrics.REGISTERED_HOOKS.clear()
+    custom_metrics.REGISTERED_HOOKS.update(previous)
+
+
+def test_metrics_file_import_and_registration(caplog, metrics_file: Path):
+    caplog.set_level(logging.INFO)
+    custom_metrics.import_metrics_hooks_files([metrics_file])
+
+    print(caplog.text)
+    assert re.search(f"Imported.*from.*{metrics_file}", caplog.text)
+    assert re.search(f"Registered metric hook:.*{EXPECTED_METRIC_HOOK_NAME}", caplog.text)
+    assert EXPECTED_METRIC_HOOK_NAME in custom_metrics.REGISTERED_HOOKS
+
+
+def test_metrics_execution(metrics_file: Path):
+    """Checks that metrics can be executed with the process_registered_metrics"""
+    metric_name = EXPECTED_METRIC_HOOK_NAME
+    results = {}
+    stdout = "\n".join("12345678")
+    stderr = "\n".join("1234567890")
+    exit_code = 1
+    results = custom_metrics.process_registered_metrics(results, stdout, stderr, exit_code)
+    assert not results
+    custom_metrics.import_metrics_hooks_files([metrics_file])
+    results = custom_metrics.process_registered_metrics(results, stdout, stderr, exit_code)
+    assert metric_name in results
+    metric = results[metric_name]
+    assert "stdout" in metric and "stderr" in metric
+    assert metric["stdout"] == 8 and metric["stderr"] == 10
+
+
+def test_end_to_end_custom_metric(tmp_path: Path, metrics_file: Path):
+    log_dir = tmp_path / "log-dir"
+    python_script = tmp_path / "script.py"
+    python_script.write_text(r"print('Hello\n big \nworld!')")
+    yaml_file = tmp_path / "sample.yaml"
+    yaml_file.write_text(f"""
+test_custom_metric:
+    generated: true
+    cmd: python3 {python_script}
+    """)
+    out = test_commands.run_command_fail_explicitly(
+        [
+            sys.executable, "-m", "examples_utils", "benchmark", "--spec",
+            str(yaml_file), "--custom-metrics-files",
+            str(metrics_file), "--log-dir",
+            str(log_dir)
+        ],
+        ".",
+    )
+    assert "PASSED test_custom_metric::test_custom_metric" in out
+    result_files = list(log_dir.rglob("benchmark_results.json"))
+    assert result_files and len(result_files) == 1, f"benchmark results could not be found in {log_dir}"
+    with open(result_files[0]) as f:
+        results = json.load(f)
+        print(results)
+
+    assert "test_custom_metric" in results
+    assert "results" in results["test_custom_metric"][0]
+    # Check that the custom metric was calculated
+    assert EXPECTED_METRIC_HOOK_NAME in results["test_custom_metric"][0]["results"]
+    metric = results["test_custom_metric"][0]["results"][EXPECTED_METRIC_HOOK_NAME]
+    print(out)
+    assert metric["stdout"] == 3 and metric["stderr"] == 0


### PR DESCRIPTION
This commit makes it possible to register parsing functions which will be
applied to the log output of a benchmark. This is implemented in the
custom_metrics.py which includes a usage example. The same usage
example is put to the test in test_custom_metrics.

These features are added to the standard benchmarks command under
the `--custom-metrics-files` argument.

This PR also adds a `--csv-metrics` argument which lets you specify a list of CSV columns
that you want to be printed.