### PR TITLE
Slurm utils fix

### DIFF
--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -502,7 +502,8 @@ def parse_benchmark_specs(spec_files: List[str]):
 def run_benchmarks_from_spec(spec: Dict[str, BenchmarkDict], args: argparse.Namespace):
     results = {}
     output_log_path = Path(args.log_dir, "output.log")
-    import_metrics_hooks_files(args.custom_metrics_files)
+    if args.custom_metrics_files is not None:
+        import_metrics_hooks_files(args.custom_metrics_files)
     with open(output_log_path, "w", buffering=1) as listener:
         print("\n" + "#" * 80)
         logger.info(f"Logs at: {output_log_path}")

--- a/examples_utils/benchmarks/slurm_utils.py
+++ b/examples_utils/benchmarks/slurm_utils.py
@@ -97,7 +97,7 @@ def configure_job_environment(args: argparse.ArgumentParser, variant_dict: Dict,
     """
 
     # get application root path
-    variant_log_dir_parts = variant_log_dir.parts
+    variant_log_dir_parts = Path(variant_dict["benchmark_path"]).parts
     examples_internal_index = variant_log_dir_parts.index("examples-internal")
     application_root = Path(*variant_log_dir_parts[0:examples_internal_index + 4])
 


### PR DESCRIPTION
- fix unchecked None type custom_metrics_path variable
- base application root for slurm utils on the benchmark path rather than the log directory