### PR TITLE
using deepcopy to preserve os.environ type

### DIFF
--- a/examples_utils/benchmarks/environment_utils.py
+++ b/examples_utils/benchmarks/environment_utils.py
@@ -279,7 +279,7 @@ def expand_environment_variables(cmd: str, new_env: dict) -> str:
     """
 
     # temporarily set os.environ to new env vars
-    orig_env = os.environ.copy()
+    orig_env = copy.deepcopy(os.environ)
     os.environ = new_env
 
     # expand vars against the new environment variables and revert os.environ


### PR DESCRIPTION
Fix suggested by @kundaMwiza for preserving the type of os.environ in a python environment. 

The previous overwrite was due to an os.environ object being overwritten by a dict, which was causing issues later with wandb. 

this should fix it.