### PR TITLE
Fixing ignore-error and wandb args

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -120,6 +120,33 @@ def get_benchmark_variants(benchmark_name: str, benchmark_dict: dict) -> list:
     return variants
 
 
+def remove_wandb_args(cmd: str) -> str:
+    """Remove all wandb args and their values from command strings.
+    """
+
+    new_arg_list = []
+    arg_list = cmd.split(" ")
+    
+    skip = False
+    for i in len(arg_list):
+        if "--" in arg_list[i] and "wandb" in arg_list[i]:
+            # Also remove the values given to wandb args using a skip bool for
+            # next iteration
+            if not "--" in arg_list[i+1]:
+                skip = True 
+            continue
+        
+        if skip:
+            continue
+
+        new_arg_list.append(arg_list[i])
+        skip = False
+    
+    new_cmd = " ".join(new_arg_list)
+
+    return new_cmd
+
+
 def formulate_benchmark_command(
         benchmark_dict: dict,
         variant_dict: dict,
@@ -166,7 +193,8 @@ def formulate_benchmark_command(
                     "argument provided to the benchmark. The default value of "
                     "'--allow-wandb' (False) is overriding, purging '--wandb' "
                     "and all args containing 'wandb' from command.")
-        cmd = " ".join([x for x in cmd.split(" ") if "--wandb" not in x])
+        
+        cmd = remove_wandb_args(cmd)
 
     if args.compile_only:
         logger.info("'--compile-only' was passed here. Appending '--compile-only' to the benchmark command.")
@@ -177,7 +205,7 @@ def formulate_benchmark_command(
             logger.info("--compile-only was passed, and wandb is not used for "
                         "compile only runs, purging '--wandb' and all args "
                         "containing 'wandb' in their names from command.")
-            cmd = " ".join([x for x in cmd.split(" ") if "--wandb" not in x])
+            cmd = remove_wandb_args(cmd)
 
         # Remove vipu settings that prevent from running in compile-only mode
         cmd = re.sub(r"--vipu-partition.*?=.*?\S*", "", cmd)

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -125,15 +125,15 @@ def remove_wandb_args(cmd: str) -> str:
     """
 
     new_arg_list = []
-    arg_list = cmd.split(" ")
+    arg_list = shlex.split(cmd)
     
     skip = False
     for i in len(arg_list):
         if "--" in arg_list[i] and "wandb" in arg_list[i]:
             # Also remove the values given to wandb args using a skip bool for
             # next iteration
-            if not "--" in arg_list[i+1]:
-                skip = True 
+            if not "-" in arg_list[i+1][:2]:
+                skip = True
             continue
         
         if skip:
@@ -142,7 +142,7 @@ def remove_wandb_args(cmd: str) -> str:
         new_arg_list.append(arg_list[i])
         skip = False
     
-    new_cmd = " ".join(new_arg_list)
+    new_cmd = shlex.join(new_arg_list)
 
     return new_cmd
 

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -140,10 +140,10 @@ def remove_wandb_args(cmd: str) -> str:
             continue
         
         if skip:
+            skip = False
             continue
 
         new_arg_list.append(arg_list[i])
-        skip = False
     
     new_cmd = shlex.join(new_arg_list)
 

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -131,11 +131,11 @@ def remove_wandb_args(cmd: str) -> str:
     
     skip = False
     arg_pattern = re.compile("^[-]+")
-    for i in range(len(arg_list)):
+    for i in range(len(arg_list) - 1):
         if arg_pattern.match(arg_list[i]) and "wandb" in arg_list[i]:
             # Also remove the values given to wandb args using a skip bool for
             # next iteration
-            if not arg_pattern.match("^[-]+", arg_list[i+1]):
+            if not arg_pattern.match(arg_list[i+1]):
                 skip = True
             continue
         

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -126,13 +126,16 @@ def remove_wandb_args(cmd: str) -> str:
 
     new_arg_list = []
     arg_list = shlex.split(cmd)
+    # Avoid out of bounds access attempt
+    arg_list.append("")
     
     skip = False
-    for i in len(arg_list):
-        if "--" in arg_list[i] and "wandb" in arg_list[i]:
+    arg_pattern = re.compile("^[-]+")
+    for i in range(len(arg_list)):
+        if arg_pattern.match(arg_list[i]) and "wandb" in arg_list[i]:
             # Also remove the values given to wandb args using a skip bool for
             # next iteration
-            if not "-" in arg_list[i+1][:2]:
+            if not arg_pattern.match("^[-]+", arg_list[i+1]):
                 skip = True
             continue
         

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -128,23 +128,23 @@ def remove_wandb_args(cmd: str) -> str:
     arg_list = shlex.split(cmd)
     # Avoid out of bounds access attempt
     arg_list.append("")
-    
+
     skip = False
     arg_pattern = re.compile("^[-]+")
     for i in range(len(arg_list) - 1):
         if arg_pattern.match(arg_list[i]) and "wandb" in arg_list[i]:
             # Also remove the values given to wandb args using a skip bool for
             # next iteration
-            if not arg_pattern.match(arg_list[i+1]):
+            if not arg_pattern.match(arg_list[i + 1]):
                 skip = True
             continue
-        
+
         if skip:
             skip = False
             continue
 
         new_arg_list.append(arg_list[i])
-    
+
     new_cmd = shlex.join(new_arg_list)
 
     return new_cmd
@@ -196,7 +196,7 @@ def formulate_benchmark_command(
                     "argument provided to the benchmark. The default value of "
                     "'--allow-wandb' (False) is overriding, purging '--wandb' "
                     "and all args containing 'wandb' from command.")
-        
+
         cmd = remove_wandb_args(cmd)
 
     if args.compile_only:

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -674,7 +674,8 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--stop-on-error",
         action="store_true",
-        help="Do not stop on an error",
+        help=("Stop on the first error and terminate all runs, instead of "
+              "proceeding to the next benchmark"),
     )
     parser.add_argument(
         "--log-dir",

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -341,13 +341,13 @@ def run_benchmark_variant(
         err = (f"Benchmark ERROR, exited with code: ({str(exitcode)}). Please check logs for more information.")
         logger.error(err)
 
-        if not args.ignore_errors:
+        if args.stop_on_error:
             error_tail = "\n\t" + "\n\t".join(stderr.splitlines()[-10:]) + "\n"
             logger.error(f"Last 10 lines of stderr from {variant_name}:{error_tail}")
             sys.excepthook = lambda exctype, exc, traceback: print("{}: {}".format(exctype.__name__, exc))
             raise RuntimeError(err)
         else:
-            logger.info("Continuing to next benchmark as `--ignore-error` was passed")
+            logger.info("Continuing to next benchmark as `--stop-on-error` was not passed")
 
     # Get 'data' metrics, these are metrics scraped from the log
     results, extraction_failure = extract_metrics(
@@ -672,7 +672,7 @@ def benchmarks_parser(parser: argparse.ArgumentParser):
               "'--benchmarks'."),
     )
     parser.add_argument(
-        "--ignore-errors",
+        "--stop-on-error",
         action="store_true",
         help="Do not stop on an error",
     )


### PR DESCRIPTION
Two fixes for args in benchmarking:
- Ignoring errors is now the default behaviour, with a new optional arg to stop on error instead of the old one to continue on errors
- wandb arg removal needs to be a bit more complicated due to some args that do wandb things having values passed to them too