### PR TITLE
Slurm utils fix for new resource contraints on CL1 Neverland

### DIFF
--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -390,7 +390,8 @@ def run_benchmark_variant(
     # Get 'data' metrics, these are metrics scraped from the log
     results, extraction_failure = extract_metrics(
         benchmark_dict.get("data", {}),
-        stdout + stderr,
+        stdout,
+        stderr,
         exitcode,
         get_mpinum(variant_command),
     )

--- a/examples_utils/benchmarks/slurm_utils.py
+++ b/examples_utils/benchmarks/slurm_utils.py
@@ -32,15 +32,15 @@ class StringFileEmulator:
         self.file_path = file_path
         self._open_for_reading()
 
-    def _open_for_reading(self):
+    def _open_for_reading(self) -> None:
         self.file = open(self.file_path, "r")
 
-    def splitlines(self) -> Generator:
+    def splitlines(self):
         self.file.seek(0)
         for line in self.file:
             yield line
 
-    def split(self, str_pattern: str) -> Generator:
+    def split(self, str_pattern: str):
         self.file.seek(0)
         if str_pattern == "\n":
             for line in self.file:
@@ -51,10 +51,16 @@ class StringFileEmulator:
                     yield elem
 
     def __add__(self, rh_str: str) -> StringFileEmulator:
-        self.file.close()
-        with open(self.file_path, "a") as f:
-            f.write(rh_str)
-        self._open_for_reading()
+        if isinstance(rh_str, str):
+            self.file.close()
+            with open(self.file_path, "a") as f:
+                f.write(rh_str)
+            self._open_for_reading()
+            return self
+        else:
+            raise ValueError(
+                "binary operator `+` with `StringFileEmulator` objects only supported with `str` right hand side operands"
+            )
 
     def __contains__(self, value: Any) -> bool:
         self.file.seek(0)

--- a/examples_utils/benchmarks/slurm_utils.py
+++ b/examples_utils/benchmarks/slurm_utils.py
@@ -226,14 +226,12 @@ def configure_job_environment(
     framework = variant_name[0:3]
     if framework == "pyt":
         packages = "poptorch-*.whl"
-    elif framework == "tf1":
-        packages = "tensorflow-1*${CPU_ARCH}*.whl ipu_tensorflow_addons-1*.whl"
     elif framework == "tf2":
         packages = "tensorflow-2*${CPU_ARCH}*.whl ipu_tensorflow_addons-2*.whl keras-2*.whl"
     elif framework == "pop":
         pass
     else:
-        err_msg = "Benchmark name should begin with pytorch, popart, tf1 or tf2."
+        err_msg = "Benchmark name should begin with pytorch, popart or tf2. Other frameworks are not supported."
         raise ValueError(err_msg)
 
     if framework != "pop":


### PR DESCRIPTION
Neverland CL1 has resource constraints of 500MB and a share of 1 CPU. This PR makes changes to slurm utils by providing an object that can behave like a string, but also like a file when reading stdout and stderr. When processing stdout and stderr, the content is processed line by line from a file to prevent OOM