### PR TITLE
Centralise `simple-parsing` utilities

### DIFF
--- a/examples_utils/parsing/simple_parsing_tools.py
+++ b/examples_utils/parsing/simple_parsing_tools.py
@@ -1,18 +1,24 @@
-# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
-import argparse
+# Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 import json
-from dataclasses import dataclass, fields
+import yaml
 from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Tuple, Union
+from dataclasses import dataclass, fields
 
-import yaml
-from simple_parsing import ArgumentParser
-from simple_parsing.helpers import Serializable, field
-from simple_parsing.helpers.serialization.decoding import register_decoding_fn
-from simple_parsing.helpers.serialization.encoding import encode
-from simple_parsing.utils import Dataclass, DataclassType
-
+import argparse
+try:
+    from simple_parsing import ArgumentParser
+    from simple_parsing.helpers import Serializable, field
+    from simple_parsing.helpers.serialization.decoding import register_decoding_fn
+    from simple_parsing.helpers.serialization.encoding import encode
+    from simple_parsing.utils import Dataclass, DataclassType
+except (ImportError, ModuleNotFoundError) as error:
+    raise  ModuleNotFoundError(
+        "To use simple parsing utilities `examples_utils` needs to have been installed with "
+        "the [common] set of requirements, reinstall the package with"
+        " `pip install examples_utils[common]`"
+    ) from error
 
 @dataclass
 class Config(Serializable):
@@ -93,17 +99,11 @@ def parse_args_with_presets(
 
     # This is here only for the help message
     parser.add_argument(
-        "--config",
-        choices=presets,
-        type=str,
-        default=default,
-        help=f"Preset Configs from {config_file}",
     )
 
     if custom_args:
         custom_args(parser)
 
-    args = parser.parse_args(remaining_argv)
     if cargs.config is not None:
         set_dataclass_defaults(dclass, defaults)
         args.config = cargs.config

--- a/examples_utils/parsing/simple_parsing_tools.py
+++ b/examples_utils/parsing/simple_parsing_tools.py
@@ -61,6 +61,14 @@ def parse_args_with_config_file(dclass: DataclassType[Dataclass], *args) -> Data
     return getattr(args, dclass_dest)
 
 
+def in_jupyter() -> bool:
+    try:
+        get_ipython()
+        return True
+    except:
+        return False
+
+
 def parse_args_with_presets(
     dclass: DataclassType[Dataclass],
     config_file: Union[str, Path],
@@ -99,11 +107,16 @@ def parse_args_with_presets(
 
     # This is here only for the help message
     parser.add_argument(
+        "--config", choices=presets, type=str, default=default, help=f"Preset Configs from {config_file}"
     )
 
     if custom_args:
         custom_args(parser)
 
+    if not in_jupyter():
+        args = parser.parse_args(remaining_argv)
+    else:
+        args, _ = parser.parse_known_args(remaining_argv)
     if cargs.config is not None:
         set_dataclass_defaults(dclass, defaults)
         args.config = cargs.config

--- a/examples_utils/parsing/simple_parsing_tools.py
+++ b/examples_utils/parsing/simple_parsing_tools.py
@@ -7,6 +7,7 @@ from typing import Any, Callable, Dict, Optional, Tuple, Union
 from dataclasses import dataclass, fields
 
 import argparse
+
 try:
     from simple_parsing import ArgumentParser
     from simple_parsing.helpers import Serializable, field
@@ -14,11 +15,12 @@ try:
     from simple_parsing.helpers.serialization.encoding import encode
     from simple_parsing.utils import Dataclass, DataclassType
 except (ImportError, ModuleNotFoundError) as error:
-    raise  ModuleNotFoundError(
+    raise ModuleNotFoundError(
         "To use simple parsing utilities `examples_utils` needs to have been installed with "
         "the [common] set of requirements, reinstall the package with"
         " `pip install examples_utils[common]`"
     ) from error
+
 
 @dataclass
 class Config(Serializable):

--- a/examples_utils/parsing/simple_utils.py
+++ b/examples_utils/parsing/simple_utils.py
@@ -1,0 +1,131 @@
+# Copyright (c) 2023 Graphcore Ltd. All rights reserved.
+import argparse
+import json
+from dataclasses import dataclass, fields
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional, Tuple, Union
+
+import yaml
+from simple_parsing import ArgumentParser
+from simple_parsing.helpers import Serializable, field
+from simple_parsing.helpers.serialization.decoding import register_decoding_fn
+from simple_parsing.helpers.serialization.encoding import encode
+from simple_parsing.utils import Dataclass, DataclassType
+
+
+@dataclass
+class Config(Serializable):
+    pass
+
+
+def flag(default: bool, *args, **kwargs):
+    """Use this to have a bool argument that's true when used as a flag.
+    For example: "--dropout" always means True"""
+    return field(default=default, nargs="?", const=True, *args, **kwargs)
+
+
+def set_dataclass_defaults(dataclass: DataclassType[Dataclass], defaults: Dataclass):
+    assert isinstance(defaults, dataclass)
+
+    for field in fields(dataclass):
+        field.default = getattr(defaults, field.name)
+
+
+def parse_args_with_config_file(dclass: DataclassType[Dataclass], *args) -> Dataclass:
+    cparser = argparse.ArgumentParser("Config Parser", add_help=False)
+    cparser.add_argument("--config", type=str)
+    cargs, remaining_argv = cparser.parse_known_args(*args)
+
+    defaults = dclass()
+    if cargs.config is not None:
+        set_dataclass_defaults(dclass, dclass.load(cargs.config, drop_extra_fields=False))
+
+    dclass_dest = dclass.__name__.lower()
+
+    parser = ArgumentParser()
+    parser.add_arguments(dclass, dest=dclass_dest)
+
+    # This is here only for the help message
+    parser.add_argument("--config", type=str, help="Path to preset config")
+
+    args = parser.parse_args(remaining_argv)
+    if cargs.config is not None:
+        set_dataclass_defaults(dclass, defaults)
+    return getattr(args, dclass_dest)
+
+
+def parse_args_with_presets(
+    dclass: DataclassType[Dataclass],
+    config_file: Union[str, Path],
+    presets_key: str,
+    default: str,
+    custom_args: Optional[Callable[[ArgumentParser], None]] = None,
+    CLI_args: Optional[str] = None,
+) -> Tuple[Dataclass, argparse.Namespace]:
+    config_file = str(config_file)
+    if config_file.endswith((".yml", ".yaml")):
+        with open(config_file) as fp:
+            config_dict: Dict[str, Any] = yaml.full_load(fp)
+    elif config_file.endswith(".json"):
+        with open(config_file) as fp:
+            config_dict: Dict[str, Any] = json.load(fp)
+    else:
+        raise ValueError("Unknown config file type.")
+
+    if presets_key:
+        config_dict = config_dict[presets_key]
+
+    presets = list(config_dict.keys())
+
+    cparser = argparse.ArgumentParser("Config Parser", add_help=False)
+    cparser.add_argument("--config", choices=presets, type=str, default=default)
+    cargs, remaining_argv = cparser.parse_known_args(CLI_args)
+
+    defaults = dclass()
+    if cargs.config is not None:
+        set_dataclass_defaults(dclass, dclass.from_dict(config_dict[cargs.config], drop_extra_fields=False))
+
+    dclass_dest = dclass.__name__.lower()
+
+    parser = ArgumentParser()
+    parser.add_arguments(dclass, dest=dclass_dest)
+
+    # This is here only for the help message
+    parser.add_argument(
+        "--config",
+        choices=presets,
+        type=str,
+        default=default,
+        help=f"Preset Configs from {config_file}",
+    )
+
+    if custom_args:
+        custom_args(parser)
+
+    args = parser.parse_args(remaining_argv)
+    if cargs.config is not None:
+        set_dataclass_defaults(dclass, defaults)
+        args.config = cargs.config
+
+    config = getattr(args, dclass_dest)
+    return config, args
+
+
+class Choice(Enum):
+    def __init_subclass__(cls) -> None:
+        if not hasattr(cls, "decode"):
+
+            def decode(value):
+                return cls[value]
+
+            setattr(cls, "decode", decode)
+        register_decoding_fn(cls, cls.decode)
+
+        if not hasattr(cls, "encode"):
+
+            def _encode(enum):
+                return str(enum.name)
+
+            setattr(cls, "encode", _encode)
+        encode.register(cls, cls.encode)

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,1 +1,1 @@
-examples_utils==0.0.19.post1
+simple-parsing==0.0.19.post1

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,0 +1,1 @@
+examples_utils==0.0.19.post1

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ def get_version():
 extra_requires = {
     "dev": read_requirements("requirements-dev.txt"),
     "jupyter": read_requirements("requirements-jupyter.txt"),
+    "common": read_requirements("requirements-common.txt"),
 }
 extra_requires["all"] = extra_requires["dev"] + extra_requires["jupyter"]
 


### PR DESCRIPTION
As discussed on Slack this PR moves the `simple_parsing_tools` from the PopXL apps to examples-utils.

This PR also makes those utilities work nicely in notebooks.