### PR TITLE
Make the copyright work for tutorials files

### DIFF
--- a/examples_utils/testing/test_copyright.py
+++ b/examples_utils/testing/test_copyright.py
@@ -30,10 +30,10 @@ def check_file(path, amend):
     first_line_index = 0
     line = "\n"
     with open(path, "r") as f:
-        regexp = r"{} Copyright \(c\) \d+ Graphcore Ltd. All (r|R)ights (r|R)eserved.".format(comment)
+        regexp = r"({} )*Copyright \(c\) \d+ Graphcore Ltd. All (r|R)ights (r|R)eserved.".format(comment)
 
         # Skip blank, comments and shebang
-        while (line == "\n" or line.startswith(comment) or line.startswith("#!")) and not re.match(regexp, line):
+        while (line == "\n" or line.startswith('"""') or line.startswith("'''") or line.startswith(comment) or line.startswith("#!")) and not re.match(regexp, line):
             if line.startswith("#!"):
                 first_line_index += 1
             line = f.readline()

--- a/examples_utils/testing/test_copyright.py
+++ b/examples_utils/testing/test_copyright.py
@@ -33,7 +33,13 @@ def check_file(path, amend):
         regexp = r"({} )*Copyright \(c\) \d+ Graphcore Ltd. All (r|R)ights (r|R)eserved.".format(comment)
 
         # Skip blank, comments and shebang
-        while (line == "\n" or line.startswith('"""') or line.startswith("'''") or line.startswith(comment) or line.startswith("#!")) and not re.match(regexp, line):
+        while (
+            line == "\n"
+            or line.startswith('"""')
+            or line.startswith("'''")
+            or line.startswith(comment)
+            or line.startswith("#!")
+        ) and not re.match(regexp, line):
             if line.startswith("#!"):
                 first_line_index += 1
             line = f.readline()


### PR DESCRIPTION
Tutorials can have a slightly different format where the coppyright
appears as

```
"""
Copyright ...
"""
```

This let's this script recognise those as correct.