### PR TITLE
Update __init__.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,4 +30,4 @@ repos:
       pass_filenames: false
       language: python
       additional_dependencies:
-        - 'git+https://github.com/graphcore/examples-utils@latest_stable'
+        - .

--- a/examples_utils/parsing/__init__.py
+++ b/examples_utils/parsing/__init__.py
@@ -1,3 +1,4 @@
 # Copyright (c) 2022 Graphcore Ltd. All rights reserved.
 
 from .file_argparse import *
+from .simple_parsing_tools import *

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -1,1 +1,0 @@
-simple-parsing==0.0.19.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ cppimport>=22.07.17
 filelock
 psutil>=5.7.0
 pyyaml>=5.4.1
+simple-parsing==0.0.19.post1


### PR DESCRIPTION
Change to expose `simple_parsing_tools` so it can be accessed via top level import. This requires moving `simple_parsing` to the base requirements which should be fine, as going forward apps will use this as their primary configuration util.