### PR TITLE
prepare env only for selected benchmarks

### DIFF
--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -180,7 +180,7 @@ def assess_platform(args: argparse.Namespace):
         try:
             logger.info("-" * 40)
             for name, benchmark in benchmarks.items():
-                if args.benchmark and if name not in args.benchmark:
+                if args.benchmark and name not in args.benchmark:
                     continue
                 logger.info(f"Preparing environment for '{name}'")
                 revertible_changes[name] = prepare_benchmark_environment(

--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -180,6 +180,8 @@ def assess_platform(args: argparse.Namespace):
         try:
             logger.info("-" * 40)
             for name, benchmark in benchmarks.items():
+                if args.benchmark and if name not in args.benchmark:
+                    continue
                 logger.info(f"Preparing environment for '{name}'")
                 revertible_changes[name] = prepare_benchmark_environment(
                     benchmark,

--- a/examples_utils/benchmarks/requirements_utils.py
+++ b/examples_utils/benchmarks/requirements_utils.py
@@ -193,6 +193,8 @@ def assess_platform(args: argparse.Namespace):
         finally:
             # Make sure that clean up happens even on failures
             for name, benchmark in benchmarks.items():
+                if args.benchmark and name not in args.benchmark:
+                    continue
                 logger.info(f"Cleaning-up environment for '{name}'")
                 cleanup_benchmark_environments(benchmark, revertible_changes.get(name))
 


### PR DESCRIPTION
Currently, if testing is narrowed to selected benchmarks still virtual envs are prepared for all benchmarks.
This can take a lot of time.
In Paperspace CI, each benchmarks is tested in separate job so installing deps for all benchmarks is a waste of time.

This change checks what benchmarks were selected and only for these benchmarks virtual envs are prepared and cleaned up.