### PR TITLE
Remove unused import

### DIFF
--- a/examples_utils/paperspace_utils/metadata_utils.py
+++ b/examples_utils/paperspace_utils/metadata_utils.py
@@ -6,7 +6,6 @@ To use import the check_files_match_metadata function:
 check_files_match_metadata(dataset_folder: str, compare_hash: bool)
 """
 
-from importlib.metadata import metadata
 from typing import NamedTuple, List
 from pathlib import Path
 import os


### PR DESCRIPTION
Remove unused import metadata

Metadata tests passed locally
test_metadata.py::test_accurate_metadata PASSED                                                                              [ 25%]
test_metadata.py::test_extra_file_in_metadata PASSED                                                                         [ 50%]
test_metadata.py::test_extra_file_locally PASSED                                                                             [ 75%]
test_metadata.py::test_file_size_inaccurate_in_metadata PASSED   