### PR TITLE
Make pre-commit open a PR with it's changes

### DIFF
--- a/.github/workflows/pre-commit-checks.yaml
+++ b/.github/workflows/pre-commit-checks.yaml
@@ -21,6 +21,17 @@ jobs:
       - name: Run pre-commit
         id: pre-commit
         run: pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref origin/${{ github.head_ref }}
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666
+        id: create-precommit-pr
+        if: always()
+        with:
+          title: Modified files for ${{ github.head_ref }}
+          body: "Automatic PR capturing the changes from pre-commit in PR #${{ github.event.number }}"
+          base: ${{ github.head_ref }}
+          labels: automated-pr
+          branch: gh-action-branches/${{ github.head_ref }}
+          delete-branch: true
       - name: Find Comment
         uses: peter-evans/find-comment@81e2da3af01c92f83cb927cf3ace0e085617c556  # v2.2.0 (pinned for security reasons)
         id: fc
@@ -37,7 +48,11 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
             **Pre-commit checks failed.**
-            
+
+            Apply them to the current branch (${{ github.head_ref }}) by merging PR #${{ steps.create-precommit-pr.outputs.pull-request-number }}
+
+            **Alternatively run pre-commit locally**
+
             Please install pre-commit so that your changes are checked before committing and pushing to GitHub. Run the following in the root of this repo:
             ```
             pip3 install pre-commit
@@ -52,6 +67,6 @@ jobs:
             git commit -a -m "Save work"
             pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.head_ref }}
             ```
-            
+
             You can use `git commit --no-verify` to bypass pre-commit however your PR will fail the pre-commit CI checks.
           edit-mode: replace


### PR DESCRIPTION
Pre-commit is great at suggesting changes, now it does it on github by opening a PR that you can merge into yours. Already in examples and Paperspace repos.