### PR TITLE
kill process more robustly, use variant-specific timeout if specified

### DIFF
--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -5,14 +5,14 @@ import re
 import subprocess
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 import shlex
 
 # Get the module logger
 logger = logging.getLogger(__name__)
 
 
-def determine_variant_timeout(global_timeout, benchmark_dict):
+def determine_variant_timeout(global_timeout: Optional[float], benchmark_dict):
     """Determine timeout for a benchmark variant,
     using the global timeout and variant-specific timeout, if specified.
     """

--- a/examples_utils/benchmarks/command_utils.py
+++ b/examples_utils/benchmarks/command_utils.py
@@ -12,6 +12,19 @@ import shlex
 logger = logging.getLogger(__name__)
 
 
+def determine_variant_timeout(global_timeout, benchmark_dict):
+    """Determine timeout for a benchmark variant,
+    using the global timeout and variant-specific timeout, if specified.
+    """
+    app_timeout = benchmark_dict.get("timeout")
+    if global_timeout is None:
+        return app_timeout
+    elif app_timeout is None:
+        return global_timeout
+    else:
+        return min(global_timeout, app_timeout)
+
+
 def create_variants(benchmark_name: str, benchmark_dict: dict) -> list:
     """Create all variants from a benchmark entry.
 

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -15,11 +15,13 @@ from typing import Tuple, Union, Dict, List
 import yaml
 import json
 import time
+import psutil
 from examples_utils.benchmarks.command_utils import (
     formulate_benchmark_command,
     get_benchmark_variants,
     get_local_poprun_hosts,
     get_poprun_config,
+    determine_variant_timeout,
 )
 from examples_utils.benchmarks.distributed_utils import remove_distributed_filesystems, setup_distributed_filesystems
 from examples_utils.benchmarks.environment_utils import (
@@ -122,6 +124,14 @@ def run_and_monitor_progress(
     outs = [[], []]
     ipu_monitoring: List[str] = []
 
+    def kill_process(proc_pid):
+        process = psutil.Process(proc_pid)
+        for proc in process.children(recursive=True):
+            logger.info("Killing child process %s" % proc.pid)
+            proc.kill()
+        logger.info("Killing process %s" % proc_pid) 
+        process.kill()
+
     def proc_thread():
         sel = selectors.DefaultSelector()
         sel.register(proc.stdout, selectors.EVENT_READ)
@@ -189,7 +199,7 @@ def run_and_monitor_progress(
         if timeout is not None and elapsed_time >= timeout:
             logger.error("TIMEOUT")
             timeout_error = True
-            proc.kill()
+            kill_process(proc.pid)
 
         if curr_time > next_trace_time:
             next_trace_time = curr_time + trace_period
@@ -336,10 +346,11 @@ def run_benchmark_variant(
         if args.submit_on_slurm:
             stdout, stderr, exitcode = run_and_monitor_progress_on_slurm(listener=listener, **slurm_config)
         else:
+            variant_timeout = determine_variant_timeout(args.timeout, benchmark_dict)
             stdout, stderr, exitcode, monitor_log = run_and_monitor_progress(
                 cmd,
                 listener,
-                args.timeout,
+                variant_timeout,
                 trace_period=args.progress_trace_period,
                 monitor_ipus=args.gc_monitor,
                 cwd=cwd,

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -124,7 +124,7 @@ def run_and_monitor_progress(
     outs = [[], []]
     ipu_monitoring: List[str] = []
 
-    def kill_process(proc_pid):
+    def kill_process(proc_pid: int):
         process = psutil.Process(proc_pid)
         for proc in process.children(recursive=True):
             logger.info("Killing child process %s" % proc.pid)

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -129,7 +129,7 @@ def run_and_monitor_progress(
         for proc in process.children(recursive=True):
             logger.info("Killing child process %s" % proc.pid)
             proc.kill()
-        logger.info("Killing process %s" % proc_pid) 
+        logger.info("Killing process %s" % proc_pid)
         process.kill()
 
     def proc_thread():

--- a/examples_utils/benchmarks/slurm_utils.py
+++ b/examples_utils/benchmarks/slurm_utils.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import shutil
 import shlex
 
-from examples_utils.benchmarks.command_utils import get_num_ipus, query_option_in_cmd
+from examples_utils.benchmarks.command_utils import get_num_ipus, query_option_in_cmd, determine_variant_timeout
 
 # Get the module logger
 logger = logging.getLogger(__name__)
@@ -628,12 +628,14 @@ def configure_slurm_job(
         job_script_path,
     ]
 
+    variant_timeout = determine_variant_timeout(args.timeout, benchmark_dict)
+
     return {
         "cmd": slurm_job_command,
         "stdout_log_path": stdout_log_path,
         "stderr_log_path": stderr_log_path,
         "job_name": variant_name,
-        "timeout": args.timeout,
+        "timeout": variant_timeout,
         "env": env,
     }
 

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -99,13 +99,13 @@ def setup_test_timeout(tmp_path_factory):
     python_filename = "sleep.py"
     py_filepath = tmp_dir / python_filename
     with open(py_filepath, "w") as f:
-        f.write("import time; time.sleep(15); print('Done')")
+        f.write("import time; time.sleep(5); print('Done')")
 
     # create yaml file containing the variant configs
     yaml_filepath = tmp_dir / "timeout_config.yaml"
     yaml_config = {
-        "timeout_variant": {"timeout": 5, "generated": True, "cmd": f"python3 {str(tmp_dir / python_filename)}"},
-        "no_timeout_variant": {"generated": True, "cmd": f"python3 {str(tmp_dir / python_filename)}"},
+        "timeout_variant": {"timeout": 2, "generated": True, "cmd": f"python3 {tmp_dir / python_filename}"},
+        "no_timeout_variant": {"generated": True, "cmd": f"python3 {tmp_dir / python_filename}"},
     }
     with open(yaml_filepath, "w") as f:
         yaml.dump(yaml_config, f, default_flow_style=False)
@@ -116,32 +116,30 @@ def setup_test_timeout(tmp_path_factory):
 @pytest.mark.usefixtures("setup_test_timeout")
 # test that the subprocess timeouts work, when set at the app and global levels
 class TestTimeout:
-    # global timeout 10s, variant timeout 5s -> should timeout in 5s
+    # global timeout 3s, variant timeout 2s -> should timeout in 2s
     def test_variant_timeout_smaller(self, setup_test_timeout):
         yaml_config = setup_test_timeout
-        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant --timeout 10"
+        cmd = f"python3 -m examples_utils benchmark --spec {yaml_config} --benchmark timeout_variant --timeout 3"
         result = subprocess.run(cmd.split(), capture_output=True, text=True)
-        assert "Timeout (5)" in result.stderr
+        assert "Timeout (2)" in result.stderr
 
-    # global timeout 3s, variant timeout 5s -> should timeout in 3s
+    # global timeout 1s, variant timeout 2s -> should timeout in 1s
     def test_variant_timeout_larger(self, setup_test_timeout):
         yaml_config = setup_test_timeout
-        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant --timeout 3"
+        cmd = f"python3 -m examples_utils benchmark --spec {yaml_config} --benchmark timeout_variant --timeout 1"
         result = subprocess.run(cmd.split(), capture_output=True, text=True)
-        assert "Timeout (3)" in result.stderr
+        assert "Timeout (1)" in result.stderr
 
-    # no global timeout, variant timeout 5s -> should timeout in 5s
+    # no global timeout, variant timeout 2s -> should timeout in 2s
     def test_only_variant_timeout(self, setup_test_timeout):
         yaml_config = setup_test_timeout
-        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant"
+        cmd = f"python3 -m examples_utils benchmark --spec {yaml_config} --benchmark timeout_variant"
         result = subprocess.run(cmd.split(), capture_output=True, text=True)
-        assert "Timeout (5)" in result.stderr
+        assert "Timeout (2)" in result.stderr
 
-    # global timeout 3s, no variant timeout -> should timeout in 3s
+    # global timeout 2s, no variant timeout -> should timeout in 2s
     def test_only_global_timeout(self, setup_test_timeout):
         yaml_config = setup_test_timeout
-        cmd = (
-            f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark no_timeout_variant --timeout 3"
-        )
+        cmd = f"python3 -m examples_utils benchmark --spec {yaml_config} --benchmark no_timeout_variant --timeout 2"
         result = subprocess.run(cmd.split(), capture_output=True, text=True)
-        assert "Timeout (3)" in result.stderr
+        assert "Timeout (2)" in result.stderr

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -5,6 +5,8 @@ import os
 import pathlib
 import pytest
 import argparse
+import yaml
+import subprocess
 from examples_utils.benchmarks import environment_utils
 from examples_utils.testing import test_commands
 
@@ -87,3 +89,59 @@ class TestPoprunEnvFallback:
         assert os.getenv(safe_var) is None
         environment_utils.check_env(mocked_args, "name", command_with_safe_var)
         assert os.getenv(safe_var) is not None
+
+
+@pytest.fixture(scope="class")
+def setup_test_timeout(tmp_path_factory):
+    tmp_dir = tmp_path_factory.mktemp("test-timeout")
+
+    # create python file to be run from the yaml
+    python_filename = "sleep.py"
+    py_filepath = tmp_dir / python_filename
+    with open(py_filepath, "w") as f:
+        f.write("import time; time.sleep(15); print('Done')")
+
+    # create yaml file containing the variant configs
+    yaml_filepath = tmp_dir / "timeout_config.yaml"
+    yaml_config = {
+        "timeout_variant": {"timeout": 5, "generated": True, "cmd": f"python3 {str(tmp_dir / python_filename)}"},
+        "no_timeout_variant": {"generated": True, "cmd": f"python3 {str(tmp_dir / python_filename)}"},
+    }
+    with open(yaml_filepath, "w") as f:
+        yaml.dump(yaml_config, f, default_flow_style=False)
+
+    return yaml_filepath
+
+
+@pytest.mark.usefixtures("setup_test_timeout")
+# test that the subprocess timeouts work, when set at the app and global levels
+class TestTimeout:
+    # global timeout 10s, variant timeout 5s -> should timeout in 5s
+    def test_variant_timeout_smaller(self, setup_test_timeout):
+        yaml_config = setup_test_timeout
+        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant --timeout 10"
+        result = subprocess.run(cmd.split(), capture_output=True, text=True)
+        assert "Timeout (5)" in result.stderr
+
+    # global timeout 3s, variant timeout 5s -> should timeout in 3s
+    def test_variant_timeout_larger(self, setup_test_timeout):
+        yaml_config = setup_test_timeout
+        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant --timeout 3"
+        result = subprocess.run(cmd.split(), capture_output=True, text=True)
+        assert "Timeout (3)" in result.stderr
+
+    # no global timeout, variant timeout 5s -> should timeout in 5s
+    def test_only_variant_timeout(self, setup_test_timeout):
+        yaml_config = setup_test_timeout
+        cmd = f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark timeout_variant"
+        result = subprocess.run(cmd.split(), capture_output=True, text=True)
+        assert "Timeout (5)" in result.stderr
+
+    # global timeout 3s, no variant timeout -> should timeout in 3s
+    def test_only_global_timeout(self, setup_test_timeout):
+        yaml_config = setup_test_timeout
+        cmd = (
+            f"python3 -m examples_utils benchmark --spec {str(yaml_config)} --benchmark no_timeout_variant --timeout 3"
+        )
+        result = subprocess.run(cmd.split(), capture_output=True, text=True)
+        assert "Timeout (3)" in result.stderr


### PR DESCRIPTION
This PR makes 2 changes to the benchmarking script:
1. Allow timeouts at the benchmark-variant level. On Paperspace CI we have seen the issue where some notebooks hang/get stuck, and we want to set timeouts for these apps that are different from other apps. Previously the benchmarking scripts had a global timeout that would apply to all benchmark variants. I added logic to retrieve a variant-specific timeout in `benchmark_dict` if it's present, and to take the min of the variant-specific and global timeout. 

2. Make the 'kill process' in the event of a timeout more robust. We've seen cases where a particular notebook will hang during compilation (in C++ somewhere), and the previous way of killing the process `subprocess.Popen().kill` wasn't enough to kill the thread and so we still kept looping forever. I made a change to first kill all child processes of the parent process before killing the parent process, which resolved this issue. 

Testing:
Ran a test on Paperspace notebooks with a combination of no timeout, benchmark variant timeout and global timeout, and ensured all were encountered correctly. 