### PR TITLE
Adding the parsing utils import error throw again with help

### DIFF
--- a/examples_utils/parsing/simple_parsing_tools.py
+++ b/examples_utils/parsing/simple_parsing_tools.py
@@ -8,11 +8,17 @@ from dataclasses import dataclass, fields
 
 import argparse
 
-from simple_parsing import ArgumentParser
-from simple_parsing.helpers import Serializable, field
-from simple_parsing.helpers.serialization.decoding import register_decoding_fn
-from simple_parsing.helpers.serialization.encoding import encode
-from simple_parsing.utils import Dataclass, DataclassType
+try:
+    from simple_parsing import ArgumentParser
+    from simple_parsing.helpers import Serializable, field
+    from simple_parsing.helpers.serialization.decoding import register_decoding_fn
+    from simple_parsing.helpers.serialization.encoding import encode
+    from simple_parsing.utils import Dataclass, DataclassType
+except (ImportError, ModuleNotFoundError) as error:
+    raise ModuleNotFoundError(
+        "To use simple parsing utilities has not been installed correctly. "
+        "Please run `pip install 'simple-parsing==0.0.19.post1'"
+    ) from error
 
 
 @dataclass


### PR DESCRIPTION
Re-introducing the erros that was thrown when simple-parsing-utils wasnt properly installed or imported. 

This now offers a suggestion to manually install it in this case instead of a re-install of examples-utils, which isnt possible anymore. simple-parsing-utils is still installed in the base requirements file, however this error has been seen in SQA tests too