### PR TITLE
Avoid hangs when running benchmarks

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -13,10 +13,6 @@ jobs:
       VIRTUAL_ENV: /some/fake/venv/path
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: clang-format
         args: [-i]
   - repo: https://github.com/graphcore/examples-utils
-    rev: latest_stable
+    rev: v3.4
     hooks:
     - id: copyright-header-check
       args: [--amend]

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -8,6 +8,7 @@ try:
     from nbconvert.exporters.exporter import ResourcesDict
     from nbconvert.preprocessors import CellExecutionError, ExecutePreprocessor
     from nbformat import NotebookNode
+    import nbclient
 except (ImportError, ModuleNotFoundError) as error:
     from . import _incorrect_requirement_variant_error
 
@@ -31,7 +32,7 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     exporter = OutputExporter()
     try:
         ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-    except CellExecutionError:
+    except (CellExecutionError, nbclient.exceptions.DeadKernelError):
         output, _ = exporter.from_notebook_node(nb)
         print(output)
         raise

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -32,7 +32,7 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     exporter = OutputExporter()
     try:
         ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-    except (CellExecutionError, nbclient.exceptions.DeadKernelError):
+    except (CellExecutionError):
         output, _ = exporter.from_notebook_node(nb)
         print(output)
         raise

--- a/examples_utils/benchmarks/notebook_utils.py
+++ b/examples_utils/benchmarks/notebook_utils.py
@@ -32,7 +32,7 @@ def run_notebook(notebook_filename: str, working_directory: str, timeout: int = 
     exporter = OutputExporter()
     try:
         ep.preprocess(nb, {"metadata": {"path": f"{working_directory}"}})
-    except (CellExecutionError):
+    except (CellExecutionError, nbclient.exceptions.DeadKernelError):
         output, _ = exporter.from_notebook_node(nb)
         print(output)
         raise

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -139,7 +139,9 @@ def run_and_monitor_progress(
         eof = False
         decode_error_count = 0
         while not eof:
+            selected = 0
             for key, _ in sel.select():
+                selected += 1
                 stream = key.fileobj
                 data = stream.read1(80)
                 try:
@@ -158,7 +160,11 @@ def run_and_monitor_progress(
                     decode_error_count += 1
                     logger.info("Consecutive error count: %i Parsing data: %s triggered UnicodeDecoderError: %s", decode_error_count, data, err)
                     if proc.poll() is not None:
-                        break
+                        eof = True
+            if not selected:
+                logger.info("Selector did not pick any files to explore, polling to check for exit")
+                if proc.poll() is not None:
+                    eof = True
 
         out, err = proc.communicate()
         outs[0].append(out.decode())

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -474,12 +474,15 @@ def run_benchmark_variant(
     if not args.submit_on_slurm:
         with open(outlog_path, "w") as f:
             f.write(stdout)
+        with open(errlog_path, "w") as f:
+            f.write(stderr)
         if monitor_log:
             with open(variant_log_dir / "ipu-monitor.jsonl", "w") as f:
                 f.writelines(monitor_log)
-            plot_ipu_usage(outlog_path.parent)
-        with open(errlog_path, "w") as f:
-            f.write(stderr)
+            try:
+                plot_ipu_usage(outlog_path.parent)
+            except Exception as error:
+                logger.error("Failed to plot IPU usage, error: %s", error)
 
     # Store metrics/details for this variant and return
     variant_result = {

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -162,8 +162,9 @@ def run_and_monitor_progress(
                     if proc.poll() is not None:
                         eof = True
             if not selected:
-                logger.info("Selector did not pick any files to explore, polling to check for exit")
+                logger.debug("Selector did not pick any files to explore, polling to check for exit")
                 if proc.poll() is not None:
+                    logger.info("Selector did not pick any files to explore, and subprocess has exited. Terminating.")
                     eof = True
 
         out, err = proc.communicate()

--- a/examples_utils/benchmarks/run_benchmarks.py
+++ b/examples_utils/benchmarks/run_benchmarks.py
@@ -140,7 +140,7 @@ def run_and_monitor_progress(
         decode_error_count = 0
         while not eof:
             selected = 0
-            for key, _ in sel.select():
+            for key, _ in sel.select(timeout=10):
                 selected += 1
                 stream = key.fileobj
                 data = stream.read1(80)


### PR DESCRIPTION
The benchmarking script can hang when the process being monitored gets into a `<defunct>` state.

The pattern that will appear is that the child process will be in a zombie state and the `proc_thread` will not reach `eof`. This PR tries to make the exit more robust by closing out some of the possible infinite code paths, 2 are identified:
- infinite loop due to an error
- infinite loop because the selector does not return any entries
- infinite wait for `select` (observed in interactive debugger)
- infinite wait for `communicate` (observed in interactive debugger)

This PR also adds some QOL improvements which make sure:
- `stderr` files are printed even if the IPU usage plots can't be plotted
- `plot_ipu_usage` is in a try except (it fails regularly due to notebooks installing incompatible matlplotlib versions)

The problem is demonstrated in the PR below.

https://github.com/graphcore/Gradient-Tensorflow2-private/pull/43
task: https://graphcore.atlassian.net/browse/AIP-394